### PR TITLE
use any(), not maxloc(), to ensure portability

### DIFF
--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -3132,10 +3132,9 @@ return
        ! now find the rightmost real eigenvalue
        w%vecisreal = .true.
        where ( abs(w%alphaI) > 1e-8 ) w%vecisreal = .false.
-
+       if (.not. any(w%vecisreal)) goto 1000
        w%ew_array(:) = w%alphaR(:)/w%beta(:)
-       maxindex = maxloc(w%ew_array,w%vecisreal)
-       if (maxindex(1) == 0) goto 1000
+       maxindex = maxloc(w%ew_array,mask=w%vecisreal)
 
        tau = 1e-4 ! todo -- pass this through from above...
        ! note n/2 always even -- validated by test on entry


### PR DESCRIPTION
Fixes #5 

The code used maxloc() with a mask on the real part to find if all was complex -- in gfortran this return 0 if the mask is all false.  ifort returns 1 in this case, though, so switch to using any() to check for any .true. in the logical array