### PR TITLE
Fix norm2

### DIFF
--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -581,7 +581,8 @@ module ral_nlls_workspaces
      real(wp) :: normF0, normJF0, normF, normJF
      real(wp) :: normJFold, normJF_Newton
      real(wp) :: Delta
-     real(wp) :: normd
+     real(wp) :: norm_2_d ! 2-norm of d
+     real(wp) :: norm_S_d ! S-norm of d, where S is the scaling
      logical :: use_second_derivatives = .false.
      integer :: hybrid_count = 0
      real(wp) :: hybrid_tol = 1.0_wp

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -1470,7 +1470,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      ! check if rho increases...
      rho = (options%eta_very_successful + options%eta_too_successful) / 2
-     work%norm_2_d = 100.0_wp
+     work%norm_S_d = 100.0_wp
      call update_trust_region_radius(rho,options,status,work)
      if ( work%Delta <= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -1470,7 +1470,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      ! check if rho increases...
      rho = (options%eta_very_successful + options%eta_too_successful) / 2
-     work%normd = 100.0_wp
+     work%norm_2_d = 100.0_wp
      call update_trust_region_radius(rho,options,status,work)
      if ( work%Delta <= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'


### PR DESCRIPTION
Fixes #24 

When the subproblem is being scaled, we are currently solving it in the S-norm, where S = `diag(sqrt(scal))`.

There is a need for both ||d||_2 (which was needed for the convergence test), and ||d||_S, which is needed when we increase the TR radius.  

I've created two variables in the workspace, so that each can be used when appropriate.  This makes ||d||_2 available without any degradation in the performance solver.