### PR TITLE
Add fallbacks

### DIFF
--- a/libRALFit/include/ral_nlls.h
+++ b/libRALFit/include/ral_nlls.h
@@ -35,6 +35,7 @@ struct ral_nlls_options_d {
   int model; /* what model to use? */
   int type_of_method; /* what method to use? */
   int nlls_method; /* what nlls method to use? */
+  bool allow_fallback_method; /* switch nlls method if chosen one fails? */
   int lls_solver; /* which lls solver to use? */
   ral_nllspkgtype_d_ stop_g_absolute; /* absolute stopping tolerance for gradient*/
   ral_nllspkgtype_d_ stop_g_relative; /* relative stopping tolerance for gradient*/

--- a/libRALFit/src/ral_nlls_ciface.f90
+++ b/libRALFit/src/ral_nlls_ciface.f90
@@ -23,6 +23,7 @@ module ral_nlls_ciface
      integer(C_INT) :: model
      integer(C_INT) :: type_of_method
      integer(C_INT) :: nlls_method
+     logical(c_bool) :: allow_fallback_method
      integer(C_INT) :: lls_solver
      real(wp) :: stop_g_absolute
      real(wp) :: stop_g_relative
@@ -151,6 +152,7 @@ contains
     foptions%model = coptions%model
     foptions%type_of_method = coptions%type_of_method
     foptions%nlls_method = coptions%nlls_method
+    foptions%allow_fallback_method = coptions%allow_fallback_method
     foptions%lls_solver = coptions%lls_solver
     foptions%stop_g_absolute = coptions%stop_g_absolute
     foptions%stop_g_relative = coptions%stop_g_relative
@@ -299,6 +301,7 @@ subroutine ral_nlls_default_options_d(coptions) bind(C)
   coptions%model = foptions%model
   coptions%type_of_method = foptions%type_of_method
   coptions%nlls_method = foptions%nlls_method
+  coptions%allow_fallback_method = foptions%allow_fallback_method
   coptions%lls_solver = foptions%lls_solver
   coptions%stop_g_absolute = foptions%stop_g_absolute
   coptions%stop_g_relative = foptions%stop_g_relative

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -811,11 +811,11 @@ contains
       End If
      Else If (buildmsg(3, .False., options).And.it_type=='R') Then
 !     Level 3: Same as level 2 but long banner version
-      If (mod(inform%iter, options%print_header)==0) Then
-        Write(rec(1), Fmt=8000)
-        Write(rec(2), Fmt=9000)
-        Write(rec(3), Fmt=8000)
-        Call printmsg(3, .False., options, 3, rec)
+        If (mod(w%iter, options%print_header)==0) Then
+           Write(rec(1), Fmt=8000)
+           Write(rec(2), Fmt=9000)
+           Write(rec(3), Fmt=8000)
+           Call printmsg(3, .False., options, 3, rec)
       End If
     End If
     If (buildmsg(2, .True., options).And.it_type == 'R') Then

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -1152,7 +1152,7 @@ contains
 
              if (buildmsg(5,.False.,options)) then
                 Write(rec(1), Fmt=3040)
-                Call printmsg(3,.False.,options,1,rec)
+                Call printmsg(5,.False.,options,1,rec)
              end if
           end if
        

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -1145,11 +1145,15 @@ contains
        do while (.not. subproblem_success)
           
           if  (num_methods_tried>0) then
-             ! if we're trying this method for the second time,
-             ! return to user
-             if (subproblem_method == options%nlls_method) Go To 100
-             ! only use fallback if the options say it's ok
-             if (.not. options%allow_fallback_method) Go To 100
+             ! If we're using a method for the second time, or
+             ! we're not allowing a fallback, then bail...
+             if ( (subproblem_method == options%nlls_method) .or. & 
+                  (.not. options%allow_fallback_method)) Go To 100
+
+             if (buildmsg(5,.False.,options)) then
+                Write(rec(1), Fmt=3040)
+                Call printmsg(3,.False.,options,1,rec)
+             end if
           end if
        
           if ( options%type_of_method == 1) then
@@ -1318,6 +1322,7 @@ contains
 3010 FORMAT('*** Subproblem solution found ***')
 3020 FORMAT('*** Solving the regularized subproblem using ',A,' ***')
 3030 FORMAT('*** Error or Subproblem solution NOT found ***')
+3040 FORMAT('*** Subproblem solution not found.  Trying next method ***')
 8000 Format(85('-'))
 
    END SUBROUTINE calculate_step

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -907,7 +907,7 @@ contains
 
   subroutine nlls_finalize(w,options)
     implicit none
-    type( nlls_workspace ) :: w
+    type( nlls_workspace ), intent(inout) :: w
     type( nlls_options ) :: options
     ! reset all the scalars
     w%first_call = 1
@@ -1014,7 +1014,7 @@ contains
     real(wp), intent(out) :: norm_2_d,norm_S_d
     TYPE( nlls_options ), INTENT( IN ) :: options
     TYPE( nlls_inform ), INTENT( INOUT ) :: inform
-    TYPE( calculate_step_work ) :: w
+    TYPE( calculate_step_work ), intent(inout) :: w
     Type( tenJ_type ), Intent(InOut) :: tenJ
     Type( NLLS_workspace ), Intent(InOut) :: inner_workspace
 

--- a/libRALFit/src/ral_nlls_pyiface.c
+++ b/libRALFit/src/ral_nlls_pyiface.c
@@ -286,6 +286,22 @@ bool set_opts(struct ral_nlls_options *options, PyObject *pyoptions) {
          options->nlls_method = (int) v;
          continue;
       }
+      // bool: allow_fallback_method
+      
+      if(strcmp(key_name, "allow_fallback_method")==0) {
+	int vint = PyObject_IsTrue(value); // 1 if true, 0 otherwise
+	printf("%d\n",vint);
+	if (vint == 1){
+	  options->allow_fallback_method=true;
+	}else if (vint == 0){
+	  options->allow_fallback_method=false;
+	}else{
+	  PyErr_SetString(PyExc_RuntimeError, "options['allow_fallback_method'] must be a bool.");
+	  return false;
+	}
+	continue;
+      }
+
       if(strcmp(key_name, "lls_solver")==0) {
 	long v = PyInt_AsLong(value);
 	if(v==-1 && PyErr_Occurred()) {

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -608,6 +608,8 @@ module ral_nlls_workspaces
   end type NLLS_workspace
 
   public :: setup_workspaces, remove_workspaces
+  public :: setup_workspace_dogleg, setup_workspace_AINT_tr
+  public :: setup_workspace_more_sorensen, setup_workspace_solve_galahad
 
 contains
 
@@ -1035,28 +1037,23 @@ contains
             w%solve_newton_tensor_ws, &
             options, tenJ, inner_workspace)
     else
-       if (options%type_of_method == 1) then
-          select case (options%nlls_method)
-          case (1) ! use the dogleg method
-             call remove_workspace_dogleg(w%dogleg_ws, options)
-          case(2) ! use the AINT method
-             call remove_workspace_AINT_tr(w%AINT_tr_ws, options)
-          case(3) ! More-Sorensen
-             call remove_workspace_more_sorensen(&
-                  w%more_sorensen_ws,options)
-          case (4) ! dtrs (Galahad)
-             call remove_workspace_solve_galahad(&
-                  w%solve_galahad_ws, options)
-          end select
-       elseif (options%type_of_method == 2) then
-          select case (options%nlls_method)
-          case (3) ! regularization_solver
-             call remove_workspace_regularization_solver(&
-                  w%regularization_solver_ws, options)
-          case (4) ! dtrs (Galahad)
-             call remove_workspace_solve_galahad(&
-                  w%solve_galahad_ws, options)
-          end select
+       if (w%dogleg_ws%allocated) then
+          call remove_workspace_dogleg(w%dogleg_ws, options)
+       end if
+       if (w%AINT_tr_ws%allocated) then
+          call remove_workspace_AINT_tr(w%AINT_tr_ws, options)
+       end if
+       if (w%more_sorensen_ws%allocated) then
+          call remove_workspace_more_sorensen(&
+               w%more_sorensen_ws,options)
+       end if
+       if (w%solve_galahad_ws%allocated) then 
+          call remove_workspace_solve_galahad(&
+               w%solve_galahad_ws, options)
+       end if
+       if (w%regularization_solver_ws%allocated) then 
+          call remove_workspace_regularization_solver(&
+               w%regularization_solver_ws, options)
        end if
     end if
     if (options%scale > 0) call remove_workspace_generate_scaling(w%generate_scaling_ws,options)

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -610,6 +610,7 @@ module ral_nlls_workspaces
   public :: setup_workspaces, remove_workspaces
   public :: setup_workspace_dogleg, setup_workspace_AINT_tr
   public :: setup_workspace_more_sorensen, setup_workspace_solve_galahad
+  public :: setup_workspace_regularization_solver
 
 contains
 

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -118,6 +118,11 @@ module ral_nlls_workspaces
 
      INTEGER :: nlls_method = 4
 
+!   allow the algorithm to use a different subproblem solver if one fails
+
+     LOGICAL :: allow_fallback_method = .true.
+
+     
 !  which linear least squares solver should we use?
 
      INTEGER :: lls_solver = 1

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -1038,24 +1038,19 @@ contains
             w%solve_newton_tensor_ws, &
             options, tenJ, inner_workspace)
     else
-       if (w%dogleg_ws%allocated) then
+       if (w%dogleg_ws%allocated) &
           call remove_workspace_dogleg(w%dogleg_ws, options)
-       end if
-       if (w%AINT_tr_ws%allocated) then
+       if (w%AINT_tr_ws%allocated) &
           call remove_workspace_AINT_tr(w%AINT_tr_ws, options)
-       end if
-       if (w%more_sorensen_ws%allocated) then
+       if (w%more_sorensen_ws%allocated) &
           call remove_workspace_more_sorensen(&
                w%more_sorensen_ws,options)
-       end if
-       if (w%solve_galahad_ws%allocated) then 
+       if (w%solve_galahad_ws%allocated) &
           call remove_workspace_solve_galahad(&
                w%solve_galahad_ws, options)
-       end if
-       if (w%regularization_solver_ws%allocated) then 
+       if (w%regularization_solver_ws%allocated) &
           call remove_workspace_regularization_solver(&
                w%regularization_solver_ws, options)
-       end if
     end if
     if (options%scale > 0) call remove_workspace_generate_scaling(w%generate_scaling_ws,options)
 

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -1018,7 +1018,7 @@ contains
 
   recursive subroutine remove_workspace_calculate_step(w,options,tenJ, inner_workspace)
     implicit none
-    type( calculate_step_work ), intent(out) :: w
+    type( calculate_step_work ), intent(inout) :: w
     type( nlls_options ), intent(in) :: options
     type( tenJ_type), Intent(inout) :: tenJ
     Type( NLLS_workspace), Intent(InOut) :: inner_workspace
@@ -1038,19 +1038,24 @@ contains
             w%solve_newton_tensor_ws, &
             options, tenJ, inner_workspace)
     else
-       if (w%dogleg_ws%allocated) &
+       if (w%dogleg_ws%allocated) then
           call remove_workspace_dogleg(w%dogleg_ws, options)
-       if (w%AINT_tr_ws%allocated) &
+       end if
+       if (w%AINT_tr_ws%allocated) then
           call remove_workspace_AINT_tr(w%AINT_tr_ws, options)
-       if (w%more_sorensen_ws%allocated) &
+       end if
+       if (w%more_sorensen_ws%allocated) then
           call remove_workspace_more_sorensen(&
                w%more_sorensen_ws,options)
-       if (w%solve_galahad_ws%allocated) &
+       end if
+       if (w%solve_galahad_ws%allocated) then
           call remove_workspace_solve_galahad(&
                w%solve_galahad_ws, options)
-       if (w%regularization_solver_ws%allocated) &
+       end if
+       if (w%regularization_solver_ws%allocated) then
           call remove_workspace_regularization_solver(&
                w%regularization_solver_ws, options)
+       end if
     end if
     if (options%scale > 0) call remove_workspace_generate_scaling(w%generate_scaling_ws,options)
 

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -473,6 +473,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
        options%model = default_options%model
        options%type_of_method = default_options%type_of_method
        options%nlls_method = default_options%nlls_method
+       options%allow_fallback_method = default_options%allow_fallback_method
        options%lls_solver = default_options%lls_solver
        options%stop_g_absolute = default_options%stop_g_absolute
        options%stop_g_relative = default_options%stop_g_relative

--- a/libRALFit/test/nlls_c_test.c
+++ b/libRALFit/test/nlls_c_test.c
@@ -85,14 +85,7 @@ int generic_test(int model, int method){
   double x[2] = { 2.5, 0.25 }; // Initial guess
   struct ral_nlls_inform inform;
   nlls_solve(2, m, x, eval_r, eval_J, eval_HF, &params, &options, &inform, NULL);
-  if (method==1 && model > 1){
-    printf("%s \n", inform.error_message);
-    if (inform.status != -101){
-      printf("ral_nlls() returned with error flag %d (expected -101)",inform.status);
-      return -36;
-    }
-  }
-  else if (model == 0) {
+  if (model == 0) {
     printf("%s \n", inform.error_message);
     if (inform.status != -3){
       printf("ral_nlls() returned with error flag %d (expected -3)",inform.status);

--- a/libRALFit/test/nlls_c_test.output
+++ b/libRALFit/test/nlls_c_test.output
@@ -1,5 +1,3 @@
-Model not supported in dogleg (nlls_method=1)                                    
-Model not supported in dogleg (nlls_method=1)                                    
 Unsupported model passed in options                                              
 Unsupported model passed in options                                              
 Unsupported model passed in options                                              

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -77,14 +77,7 @@ program nlls_test
               call print_line(options%out)
 
               call solve_basic(X,params,options,status)
-              if (( nlls_method == 1).and.( options%model > 1)) then
-                 if ( status%status .ne. NLLS_ERROR_DOGLEG_MODEL ) then
-                    write(*,*) 'incorrect error return from nlls_solve:'
-                    write(*,*) 'NLLS_METHOD = ', nlls_method
-                    write(*,*) 'MODEL = ', options%model
-                    no_errors_main = no_errors_main + 1
-                 end if
-              else if ( options%model == 0 ) then
+              if ( options%model == 0 ) then
                  if ( status%status .ne. -3 ) then
                     write(*,*) 'incorrect error return from nlls_solve:'
                     write(*,*) 'NLLS_METHOD = ', nlls_method
@@ -104,6 +97,27 @@ program nlls_test
            end do
         end do
      end do
+
+
+     ! dogleg, no fallback
+     call reset_default_options(options)
+     options%nlls_method = 1 ! dogleg
+     options%model = 2 ! newton
+     options%allow_fallback_method = .false.
+     options%print_level = 1
+     
+     call print_line(options%out)
+     write(options%out,*) "dogleg, model = 2, no fallback"
+     call print_line(options%out)
+          
+     call solve_basic(X,params,options,status)
+     if ( status%status .ne. NLLS_ERROR_DOGLEG_MODEL ) then
+        write(*,*) 'incorrect error return from nlls_solve:'
+        write(*,*) 'NLLS_METHOD = ', nlls_method
+        write(*,*) 'MODEL = ', options%model
+        write(*,*) 'status returned = ', status%status
+        no_errors_main = no_errors_main + 1
+     end if
      
      ! now, let's test the regularization method
      call reset_default_options(options)


### PR DESCRIPTION
Fixes #38 

The proposed solution tries the method picked in options, and then cycles through until one of the method calculates a step.  The method is reset to that chosen by the user at each iteration.

The changes apply the same method to the trust region part of the code, too, as it could also be the case that one of the four methods there fails to calculate a step.   