### PR TITLE
Cosmetic update (NormS) + Recovery exit in fall-back scheme

### DIFF
--- a/libRALFit/src/ral_nlls_printing.f90
+++ b/libRALFit/src/ral_nlls_printing.f90
@@ -281,11 +281,18 @@
      Else
         If (buildmsg(1,.False.,options)) Then
           nrec = 1
-          Write(rec(nrec), Fmt=99998) 'converged, an optimal solution was found'
+          if (inform%convergence_normf == 1 .Or. inform%convergence_normg == 1) Then
+            Write (rec(nrec),Fmt=99998)                                      &
+              'converged, an optimal solution was found'
+          Else
+            Write (rec(nrec),Fmt=99998)                                      &
+              'terminated, small step size taken'
+          End If
           nrec = nrec + 1
-          Write(rec(nrec), Fmt=60000)
+          Write (rec(nrec),Fmt=60000)
           nrec = nrec + 1
-          Write(rec(nrec), Fmt=99997) 'Norm of error                 ', inform%obj
+          Write (rec(nrec),Fmt=99997) 'Norm of error                 ',      &
+            inform%obj
           Call printmsg(1,.False.,options,nrec,rec)
         End If
         If (buildmsg(2,.False.,options)) Then


### PR DESCRIPTION
Updates:

1) exit message/status banner
2) if fall-back recovery fails then triggers a general progress failure code and not the error from the last method tried, the idea is to differentiate the scenarios when the fall-back strategy is active.

