### PR TITLE
66 fix reg docs

### DIFF
--- a/libRALFit/doc/C/examples.rst
+++ b/libRALFit/doc/C/examples.rst
@@ -9,4 +9,4 @@ Examples
 
 This returns the following output:
 
-.. literalinclude:: ../../test/c_example_output.out
+.. literalinclude:: ../../test/nlls_c_example.output

--- a/libRALFit/doc/Fortran/examples.rst
+++ b/libRALFit/doc/Fortran/examples.rst
@@ -9,4 +9,4 @@ Examples
 
 This returns the following output:
 
-.. literalinclude:: ../../test/fortran_example_output.out
+.. literalinclude:: ../../test/nlls_fortran_example.output

--- a/libRALFit/doc/common/method.rst
+++ b/libRALFit/doc/common/method.rst
@@ -272,7 +272,7 @@ minimum of the model with a regularization term added:
 .. math::
    :label: regsub
    
-   \iter{\vs} = \arg \min_{\vs} \ \iter{m} (\vs)  + \frac{1}{\Delta_k}\cdot \frac{1}{p} \|\vs\|_B^p,
+   \iter{\vs} = \arg \min_{\vs} \ \iter{m} (\vs)  + \frac{1}{\Delta_k}\cdot \frac{1}{q} \|\vs\|_B^q,
 
 At present, only one method of solving
 this subproblem is supported:
@@ -281,7 +281,7 @@ this subproblem is supported:
   this solves :eq:`regsub` by first
   converting the problem into the form
 
-  .. math:: \min_\vp \vw^T \vp + \frac{1}{2} \vp^T \vD \vp + \frac{1}{p}\|\vp\|_2^p,
+  .. math:: \min_\vp \vw^T \vp + \frac{1}{2} \vp^T \vD \vp + \frac{1}{q}\|\vp\|_2^q,
 
   where :math:`\vD` is a diagonal matrix. We do this by performing an
   eigen-decomposition of the Hessian in the model. Then, we call the

--- a/libRALFit/doc/common/method.rst
+++ b/libRALFit/doc/common/method.rst
@@ -410,10 +410,11 @@ The package supports two options:
 Incorporating the regularization term
 -------------------------------------
 
-If a non-zero regularization term is required in
-:eq:`lsq`, then this is handled by transforming the
-problem internally into a new non-linear least-squares problem. 
-The formulation used will depend on the value of ``regularization`` in |nlls_options|.
+If ``regularization = 0``, then no regularization is added.
+
+A non-zero regularization term can be used in :eq:`lsq` by setting ``regularization`` to be non-zero.
+This is done by transforming the problem internally into a new non-linear least-squares problem. 
+The formulation used will depend on the value of ``regularization`` in |nlls_options|, as described below.
 
 ``regularization = 1``
   **This is only supported if** :math:`\bf p = 2`.

--- a/libRALFit/doc/common/options.rst
+++ b/libRALFit/doc/common/options.rst
@@ -96,7 +96,7 @@
 
 .. |hybrid_switch_its| replace:: if ``model=3``, sets how many iterates in a row must the condition in the definition of ``hybrid_tol`` hold before a switch.
 
-.. |reg_order| replace:: if ``type_of_method = 2``, the order of the regularization used (:math:`p` in  (:eq:`regsub`)).   If ``reg_order = 0.0``, then the algorithm chooses an appropriate value of :math:`p`. 
+.. |reg_order| replace:: if ``type_of_method = 2``, the order of the regularization used (:math:`q` in  (:eq:`regsub`)).   If ``reg_order = 0.0``, then the algorithm chooses an appropriate value of :math:`q`. 
 
 .. |inner_method| replace::  if ``nlls_method = 4``, specifies the method used to pass in the regularization parameter to the inner non-linear least squares solver.   Possible values are:
 


### PR DESCRIPTION
Fixes #66 

@talassio : could you please check this solves this issue?  The built docs should be [here](https://ralfit.readthedocs.io/projects/Fortran/en/66-fix-reg-docs/)

