### PR TITLE
92 fix covm

### DIFF
--- a/ComparisonTools/cutest/src/ral_nlls/ral_nlls_test.f90
+++ b/ComparisonTools/cutest/src/ral_nlls/ral_nlls_test.f90
@@ -368,6 +368,13 @@ module ral_nlls_workspaces
      Integer       :: box_ls_step_maxit = 20
 !    LS type: 1 => Dennis-Schnabel; 2 => Hager-Zhang
      Integer       :: box_linesearch_type = 1
+!       Save covariance matrix type
+!         0: None
+!         1: C = inv(sigma * J^T J)
+!         2: only diagonal of C
+!         3: only J^T J
+     Integer       :: save_covm = 0
+
   END TYPE nlls_options
 
 !  - - - - - - - - - - - - - - - - - - - - - - -
@@ -481,6 +488,9 @@ module ral_nlls_workspaces
      Integer :: f_eval_pg = 0
      Integer :: g_eval_pg = 0
 
+! COVARIANCE MATRIX (VARIANCE vector or J^T*J)
+     real(wp), allocatable :: cov(:,:)
+     real(wp), allocatable :: var(:)
      
   END TYPE nlls_inform
 

--- a/libRALFit/doc/Fortran/howtouse.rst
+++ b/libRALFit/doc/Fortran/howtouse.rst
@@ -473,6 +473,8 @@ The derived data type for holding options
    :f logical output_progress_vectors [default=false]: |output_progress_vectors|
 
    :f integer save_covm [default=0]: |save_covm|
+				     
+				     .. include:: ../common/options_save_covm.txt
    
    **Internal options to help solving a regularized problem implicitly**
 

--- a/libRALFit/doc/Fortran/howtouse.rst
+++ b/libRALFit/doc/Fortran/howtouse.rst
@@ -471,6 +471,8 @@ The derived data type for holding options
    **Other options**
 					     
    :f logical output_progress_vectors [default=false]: |output_progress_vectors|
+
+   :f integer save_covm [default=0]: |save_covm|
    
    **Internal options to help solving a regularized problem implicitly**
 
@@ -532,6 +534,10 @@ The derived data type for holding information
    :f character external_name(80): |external_name|
 
    :f real step: |step|
+
+   :f real cov: |cov|
+
+   :f real var: |var|
    
 
 The workspace derived data type

--- a/libRALFit/doc/common/inform.rst
+++ b/libRALFit/doc/common/inform.rst
@@ -37,3 +37,7 @@
 .. |external_name| replace:: holds the name of the external code that flagged an error.
 
 .. |step| replace:: holds the size of the last step taken.
+
+.. |cov| replace:: On exit, optionally contains information about the covariance matrix, as requested by ``nlls_options%save_covm``.
+
+.. |var| replace::  On exit, optionally contains information about the diagonal of the covariance matrix, as requested by ``nlls_options%save_covm``.

--- a/libRALFit/doc/common/options.rst
+++ b/libRALFit/doc/common/options.rst
@@ -147,3 +147,14 @@
 
 .. |output_progress_vectors| replace:: if true, outputs the progress vectors ``nlls_inform%resvec`` and ``nlls_inform%gradvec`` at the end of the routine.
 
+.. |save_covm| replace:: Determines whether to return information about the covariance matrix in ``nlls_informm``.  Options are:
+
+.. !+----+------------------------------------------------------------------------+
+.. !|  0 | Do not return covariance matrix (default)                              |
+.. !+----+------------------------------------------------------------------------+
+.. !|  1 | Returns C = inv(sigma*J^T J) in ``nlls_inform%cov``                    |
+.. !+----+------------------------------------------------------------------------+
+.. !|  2 | Returns the diagonal of C in ``nlls_inform%var``                       |
+.. !+----+------------------------------------------------------------------------+
+.. !|  3 | Returns J^T J in ``nlls_inform%cov``                                   |
+.. !+----+------------------------------------------------------------------------+

--- a/libRALFit/doc/common/options.rst
+++ b/libRALFit/doc/common/options.rst
@@ -149,12 +149,3 @@
 
 .. |save_covm| replace:: Determines whether to return information about the covariance matrix in ``nlls_informm``.  Options are:
 
-.. !+----+------------------------------------------------------------------------+
-.. !|  0 | Do not return covariance matrix (default)                              |
-.. !+----+------------------------------------------------------------------------+
-.. !|  1 | Returns C = inv(sigma*J^T J) in ``nlls_inform%cov``                    |
-.. !+----+------------------------------------------------------------------------+
-.. !|  2 | Returns the diagonal of C in ``nlls_inform%var``                       |
-.. !+----+------------------------------------------------------------------------+
-.. !|  3 | Returns J^T J in ``nlls_inform%cov``                                   |
-.. !+----+------------------------------------------------------------------------+

--- a/libRALFit/doc/common/options_save_covm.txt
+++ b/libRALFit/doc/common/options_save_covm.txt
@@ -1,0 +1,10 @@
+.. list-table::
+
+   * - 0
+     - Do not return covariance matrix. (default)
+   * - 1
+     - Returns :math:`C = \sigma^2 inv(J^T J)` in ``nlls_inform%cov``, where :math:`\sigma^2` is the estimated variance of the residual at the solution.
+   * - 2
+     - Returns the diagonal of :math:`C` in ``nlls_inform%var``.
+   * - 3
+     - Returns :math:`J^T J` in ``nlls_inform%cov``.

--- a/libRALFit/doc/common/options_save_covm.txt
+++ b/libRALFit/doc/common/options_save_covm.txt
@@ -1,10 +1,14 @@
 .. list-table::
-
+   :widths: 1 5
+   
    * - 0
      - Do not return covariance matrix. (default)
+     
    * - 1
-     - Returns :math:`C = \sigma^2 inv(J^T J)` in ``nlls_inform%cov``, where :math:`\sigma^2` is the estimated variance of the residual at the solution.
+     - Returns :math:`C = \sigma^2 (J^T J)^{-1}` in ``nlls_inform%cov``, where :math:`\sigma^2` is the estimated variance of the residual at the solution.
+     
    * - 2
      - Returns the diagonal of :math:`C` in ``nlls_inform%var``.
+     
    * - 3
      - Returns :math:`J^T J` in ``nlls_inform%cov``.

--- a/libRALFit/lapack/CMakeLists.txt
+++ b/libRALFit/lapack/CMakeLists.txt
@@ -14,13 +14,16 @@ add_library(ral_nlls_lapack SHARED
          dlascl.f dlaset.f dlasq1.f dlasq2.f
          dlasq3.f dlasq4.f dlasq5.f dlasq6.f
          dlasr.f dlasrt.f dlassq.f dlasv2.f
-         dlaswp.f dlatrd.f dorg2l.f dorg2r.f
+         dlaswp.f dlatrd.f dlauu2.f dlauum.f
+	 dorg2l.f dorg2r.f
          dorgbr.f dorgl2.f dorglq.f dorgql.f
          dorgqr.f dorgtr.f dorm2l.f dorm2r.f
          dormbr.f dorml2.f dormlq.f dormql.f 
          dormqr.f dormtr.f dposv.f dpotrf2.f
-         dpotrf.f dpotrs.f dstebz.f dstein.f
+         dpotrf.f dpotri.f dpotrs.f dstebz.f
+	 dstein.f
          dsteqr.f dsterf.f dsyev.f dsyevx.f
-         dsytd2.f dsytrd.f dtgevc.f dtrtrs.f
+         dsytd2.f dsytrd.f dtgevc.f dtrtri.f
+	 dtrti2.f dtrtrs.f
          ieeeck.f iladlc.f iladlr.f ilaenv.f
          iparmq.f dlamch.f)

--- a/libRALFit/lapack/dlauu2.f
+++ b/libRALFit/lapack/dlauu2.f
@@ -1,0 +1,198 @@
+*> \brief \b DLAUU2 computes the product UUH or LHL, where U and L are upper or lower triangular matrices (unblocked algorithm).
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DLAUU2 + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dlauu2.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dlauu2.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dlauu2.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DLAUU2( UPLO, N, A, LDA, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          UPLO
+*       INTEGER            INFO, LDA, N
+*       ..
+*       .. Array Arguments ..
+*       DOUBLE PRECISION   A( LDA, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DLAUU2 computes the product U * U**T or L**T * L, where the triangular
+*> factor U or L is stored in the upper or lower triangular part of
+*> the array A.
+*>
+*> If UPLO = 'U' or 'u' then the upper triangle of the result is stored,
+*> overwriting the factor U in A.
+*> If UPLO = 'L' or 'l' then the lower triangle of the result is stored,
+*> overwriting the factor L in A.
+*>
+*> This is the unblocked form of the algorithm, calling Level 2 BLAS.
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] UPLO
+*> \verbatim
+*>          UPLO is CHARACTER*1
+*>          Specifies whether the triangular factor stored in the array A
+*>          is upper or lower triangular:
+*>          = 'U':  Upper triangular
+*>          = 'L':  Lower triangular
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the triangular factor U or L.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the triangular factor U or L.
+*>          On exit, if UPLO = 'U', the upper triangle of A is
+*>          overwritten with the upper triangle of the product U * U**T;
+*>          if UPLO = 'L', the lower triangle of A is overwritten with
+*>          the lower triangle of the product L**T * L.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0: successful exit
+*>          < 0: if INFO = -k, the k-th argument had an illegal value
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \date December 2016
+*
+*> \ingroup doubleOTHERauxiliary
+*
+*  =====================================================================
+      SUBROUTINE DLAUU2( UPLO, N, A, LDA, INFO )
+*
+*  -- LAPACK auxiliary routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*     December 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          UPLO
+      INTEGER            INFO, LDA, N
+*     ..
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            UPPER
+      INTEGER            I
+      DOUBLE PRECISION   AII
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      DOUBLE PRECISION   DDOT
+      EXTERNAL           LSAME, DDOT
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DGEMV, DSCAL, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX
+*     ..
+*     .. Executable Statements ..
+*
+*     Test the input parameters.
+*
+      INFO = 0
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+         INFO = -1
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -2
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -4
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DLAUU2', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+      IF( UPPER ) THEN
+*
+*        Compute the product U * U**T.
+*
+         DO 10 I = 1, N
+            AII = A( I, I )
+            IF( I.LT.N ) THEN
+               A( I, I ) = DDOT( N-I+1, A( I, I ), LDA, A( I, I ), LDA )
+               CALL DGEMV( 'No transpose', I-1, N-I, ONE, A( 1, I+1 ),
+     $                     LDA, A( I, I+1 ), LDA, AII, A( 1, I ), 1 )
+            ELSE
+               CALL DSCAL( I, AII, A( 1, I ), 1 )
+            END IF
+   10    CONTINUE
+*
+      ELSE
+*
+*        Compute the product L**T * L.
+*
+         DO 20 I = 1, N
+            AII = A( I, I )
+            IF( I.LT.N ) THEN
+               A( I, I ) = DDOT( N-I+1, A( I, I ), 1, A( I, I ), 1 )
+               CALL DGEMV( 'Transpose', N-I, I-1, ONE, A( I+1, 1 ), LDA,
+     $                     A( I+1, I ), 1, AII, A( I, 1 ), LDA )
+            ELSE
+               CALL DSCAL( I, AII, A( I, 1 ), LDA )
+            END IF
+   20    CONTINUE
+      END IF
+*
+      RETURN
+*
+*     End of DLAUU2
+*
+      END

--- a/libRALFit/lapack/dlauum.f
+++ b/libRALFit/lapack/dlauum.f
@@ -1,0 +1,218 @@
+*> \brief \b DLAUUM computes the product UUH or LHL, where U and L are upper or lower triangular matrices (blocked algorithm).
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DLAUUM + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dlauum.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dlauum.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dlauum.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DLAUUM( UPLO, N, A, LDA, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          UPLO
+*       INTEGER            INFO, LDA, N
+*       ..
+*       .. Array Arguments ..
+*       DOUBLE PRECISION   A( LDA, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DLAUUM computes the product U * U**T or L**T * L, where the triangular
+*> factor U or L is stored in the upper or lower triangular part of
+*> the array A.
+*>
+*> If UPLO = 'U' or 'u' then the upper triangle of the result is stored,
+*> overwriting the factor U in A.
+*> If UPLO = 'L' or 'l' then the lower triangle of the result is stored,
+*> overwriting the factor L in A.
+*>
+*> This is the blocked form of the algorithm, calling Level 3 BLAS.
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] UPLO
+*> \verbatim
+*>          UPLO is CHARACTER*1
+*>          Specifies whether the triangular factor stored in the array A
+*>          is upper or lower triangular:
+*>          = 'U':  Upper triangular
+*>          = 'L':  Lower triangular
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the triangular factor U or L.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the triangular factor U or L.
+*>          On exit, if UPLO = 'U', the upper triangle of A is
+*>          overwritten with the upper triangle of the product U * U**T;
+*>          if UPLO = 'L', the lower triangle of A is overwritten with
+*>          the lower triangle of the product L**T * L.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0: successful exit
+*>          < 0: if INFO = -k, the k-th argument had an illegal value
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \date December 2016
+*
+*> \ingroup doubleOTHERauxiliary
+*
+*  =====================================================================
+      SUBROUTINE DLAUUM( UPLO, N, A, LDA, INFO )
+*
+*  -- LAPACK auxiliary routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*     December 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          UPLO
+      INTEGER            INFO, LDA, N
+*     ..
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            UPPER
+      INTEGER            I, IB, NB
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      INTEGER            ILAENV
+      EXTERNAL           LSAME, ILAENV
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DGEMM, DLAUU2, DSYRK, DTRMM, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Test the input parameters.
+*
+      INFO = 0
+      UPPER = LSAME( UPLO, 'U' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+         INFO = -1
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -2
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -4
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DLAUUM', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+*     Determine the block size for this environment.
+*
+      NB = ILAENV( 1, 'DLAUUM', UPLO, N, -1, -1, -1 )
+*
+      IF( NB.LE.1 .OR. NB.GE.N ) THEN
+*
+*        Use unblocked code
+*
+         CALL DLAUU2( UPLO, N, A, LDA, INFO )
+      ELSE
+*
+*        Use blocked code
+*
+         IF( UPPER ) THEN
+*
+*           Compute the product U * U**T.
+*
+            DO 10 I = 1, N, NB
+               IB = MIN( NB, N-I+1 )
+               CALL DTRMM( 'Right', 'Upper', 'Transpose', 'Non-unit',
+     $                     I-1, IB, ONE, A( I, I ), LDA, A( 1, I ),
+     $                     LDA )
+               CALL DLAUU2( 'Upper', IB, A( I, I ), LDA, INFO )
+               IF( I+IB.LE.N ) THEN
+                  CALL DGEMM( 'No transpose', 'Transpose', I-1, IB,
+     $                        N-I-IB+1, ONE, A( 1, I+IB ), LDA,
+     $                        A( I, I+IB ), LDA, ONE, A( 1, I ), LDA )
+                  CALL DSYRK( 'Upper', 'No transpose', IB, N-I-IB+1,
+     $                        ONE, A( I, I+IB ), LDA, ONE, A( I, I ),
+     $                        LDA )
+               END IF
+   10       CONTINUE
+         ELSE
+*
+*           Compute the product L**T * L.
+*
+            DO 20 I = 1, N, NB
+               IB = MIN( NB, N-I+1 )
+               CALL DTRMM( 'Left', 'Lower', 'Transpose', 'Non-unit', IB,
+     $                     I-1, ONE, A( I, I ), LDA, A( I, 1 ), LDA )
+               CALL DLAUU2( 'Lower', IB, A( I, I ), LDA, INFO )
+               IF( I+IB.LE.N ) THEN
+                  CALL DGEMM( 'Transpose', 'No transpose', IB, I-1,
+     $                        N-I-IB+1, ONE, A( I+IB, I ), LDA,
+     $                        A( I+IB, 1 ), LDA, ONE, A( I, 1 ), LDA )
+                  CALL DSYRK( 'Lower', 'Transpose', IB, N-I-IB+1, ONE,
+     $                        A( I+IB, I ), LDA, ONE, A( I, I ), LDA )
+               END IF
+   20       CONTINUE
+         END IF
+      END IF
+*
+      RETURN
+*
+*     End of DLAUUM
+*
+      END

--- a/libRALFit/lapack/dpotri.f
+++ b/libRALFit/lapack/dpotri.f
@@ -1,0 +1,159 @@
+*> \brief \b DPOTRI
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DPOTRI + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dpotri.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dpotri.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dpotri.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DPOTRI( UPLO, N, A, LDA, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          UPLO
+*       INTEGER            INFO, LDA, N
+*       ..
+*       .. Array Arguments ..
+*       DOUBLE PRECISION   A( LDA, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DPOTRI computes the inverse of a real symmetric positive definite
+*> matrix A using the Cholesky factorization A = U**T*U or A = L*L**T
+*> computed by DPOTRF.
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] UPLO
+*> \verbatim
+*>          UPLO is CHARACTER*1
+*>          = 'U':  Upper triangle of A is stored;
+*>          = 'L':  Lower triangle of A is stored.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the triangular factor U or L from the Cholesky
+*>          factorization A = U**T*U or A = L*L**T, as computed by
+*>          DPOTRF.
+*>          On exit, the upper or lower triangle of the (symmetric)
+*>          inverse of A, overwriting the input factor U or L.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0:  successful exit
+*>          < 0:  if INFO = -i, the i-th argument had an illegal value
+*>          > 0:  if INFO = i, the (i,i) element of the factor U or L is
+*>                zero, and the inverse could not be computed.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \date December 2016
+*
+*> \ingroup doublePOcomputational
+*
+*  =====================================================================
+      SUBROUTINE DPOTRI( UPLO, N, A, LDA, INFO )
+*
+*  -- LAPACK computational routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*     December 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          UPLO
+      INTEGER            INFO, LDA, N
+*     ..
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DLAUUM, DTRTRI, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX
+*     ..
+*     .. Executable Statements ..
+*
+*     Test the input parameters.
+*
+      INFO = 0
+      IF( .NOT.LSAME( UPLO, 'U' ) .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+         INFO = -1
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -2
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -4
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DPOTRI', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+*     Invert the triangular Cholesky factor U or L.
+*
+      CALL DTRTRI( UPLO, 'Non-unit', N, A, LDA, INFO )
+      IF( INFO.GT.0 )
+     $   RETURN
+*
+*     Form inv(U) * inv(U)**T or inv(L)**T * inv(L).
+*
+      CALL DLAUUM( UPLO, N, A, LDA, INFO )
+*
+      RETURN
+*
+*     End of DPOTRI
+*
+      END

--- a/libRALFit/lapack/dtrti2.f
+++ b/libRALFit/lapack/dtrti2.f
@@ -1,0 +1,212 @@
+*> \brief \b DTRTI2 computes the inverse of a triangular matrix (unblocked algorithm).
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DTRTI2 + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dtrti2.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dtrti2.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dtrti2.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DTRTI2( UPLO, DIAG, N, A, LDA, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          DIAG, UPLO
+*       INTEGER            INFO, LDA, N
+*       ..
+*       .. Array Arguments ..
+*       DOUBLE PRECISION   A( LDA, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DTRTI2 computes the inverse of a real upper or lower triangular
+*> matrix.
+*>
+*> This is the Level 2 BLAS version of the algorithm.
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] UPLO
+*> \verbatim
+*>          UPLO is CHARACTER*1
+*>          Specifies whether the matrix A is upper or lower triangular.
+*>          = 'U':  Upper triangular
+*>          = 'L':  Lower triangular
+*> \endverbatim
+*>
+*> \param[in] DIAG
+*> \verbatim
+*>          DIAG is CHARACTER*1
+*>          Specifies whether or not the matrix A is unit triangular.
+*>          = 'N':  Non-unit triangular
+*>          = 'U':  Unit triangular
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the triangular matrix A.  If UPLO = 'U', the
+*>          leading n by n upper triangular part of the array A contains
+*>          the upper triangular matrix, and the strictly lower
+*>          triangular part of A is not referenced.  If UPLO = 'L', the
+*>          leading n by n lower triangular part of the array A contains
+*>          the lower triangular matrix, and the strictly upper
+*>          triangular part of A is not referenced.  If DIAG = 'U', the
+*>          diagonal elements of A are also not referenced and are
+*>          assumed to be 1.
+*>
+*>          On exit, the (triangular) inverse of the original matrix, in
+*>          the same storage format.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0: successful exit
+*>          < 0: if INFO = -k, the k-th argument had an illegal value
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \date December 2016
+*
+*> \ingroup doubleOTHERcomputational
+*
+*  =====================================================================
+      SUBROUTINE DTRTI2( UPLO, DIAG, N, A, LDA, INFO )
+*
+*  -- LAPACK computational routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*     December 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          DIAG, UPLO
+      INTEGER            INFO, LDA, N
+*     ..
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ONE
+      PARAMETER          ( ONE = 1.0D+0 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            NOUNIT, UPPER
+      INTEGER            J
+      DOUBLE PRECISION   AJJ
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      EXTERNAL           LSAME
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DSCAL, DTRMV, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX
+*     ..
+*     .. Executable Statements ..
+*
+*     Test the input parameters.
+*
+      INFO = 0
+      UPPER = LSAME( UPLO, 'U' )
+      NOUNIT = LSAME( DIAG, 'N' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.NOUNIT .AND. .NOT.LSAME( DIAG, 'U' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DTRTI2', -INFO )
+         RETURN
+      END IF
+*
+      IF( UPPER ) THEN
+*
+*        Compute inverse of upper triangular matrix.
+*
+         DO 10 J = 1, N
+            IF( NOUNIT ) THEN
+               A( J, J ) = ONE / A( J, J )
+               AJJ = -A( J, J )
+            ELSE
+               AJJ = -ONE
+            END IF
+*
+*           Compute elements 1:j-1 of j-th column.
+*
+            CALL DTRMV( 'Upper', 'No transpose', DIAG, J-1, A, LDA,
+     $                  A( 1, J ), 1 )
+            CALL DSCAL( J-1, AJJ, A( 1, J ), 1 )
+   10    CONTINUE
+      ELSE
+*
+*        Compute inverse of lower triangular matrix.
+*
+         DO 20 J = N, 1, -1
+            IF( NOUNIT ) THEN
+               A( J, J ) = ONE / A( J, J )
+               AJJ = -A( J, J )
+            ELSE
+               AJJ = -ONE
+            END IF
+            IF( J.LT.N ) THEN
+*
+*              Compute elements j+1:n of j-th column.
+*
+               CALL DTRMV( 'Lower', 'No transpose', DIAG, N-J,
+     $                     A( J+1, J+1 ), LDA, A( J+1, J ), 1 )
+               CALL DSCAL( N-J, AJJ, A( J+1, J ), 1 )
+            END IF
+   20    CONTINUE
+      END IF
+*
+      RETURN
+*
+*     End of DTRTI2
+*
+      END

--- a/libRALFit/lapack/dtrtri.f
+++ b/libRALFit/lapack/dtrtri.f
@@ -1,0 +1,242 @@
+*> \brief \b DTRTRI
+*
+*  =========== DOCUMENTATION ===========
+*
+* Online html documentation available at
+*            http://www.netlib.org/lapack/explore-html/
+*
+*> \htmlonly
+*> Download DTRTRI + dependencies
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dtrtri.f">
+*> [TGZ]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.zip?format=zip&filename=/lapack/lapack_routine/dtrtri.f">
+*> [ZIP]</a>
+*> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dtrtri.f">
+*> [TXT]</a>
+*> \endhtmlonly
+*
+*  Definition:
+*  ===========
+*
+*       SUBROUTINE DTRTRI( UPLO, DIAG, N, A, LDA, INFO )
+*
+*       .. Scalar Arguments ..
+*       CHARACTER          DIAG, UPLO
+*       INTEGER            INFO, LDA, N
+*       ..
+*       .. Array Arguments ..
+*       DOUBLE PRECISION   A( LDA, * )
+*       ..
+*
+*
+*> \par Purpose:
+*  =============
+*>
+*> \verbatim
+*>
+*> DTRTRI computes the inverse of a real upper or lower triangular
+*> matrix A.
+*>
+*> This is the Level 3 BLAS version of the algorithm.
+*> \endverbatim
+*
+*  Arguments:
+*  ==========
+*
+*> \param[in] UPLO
+*> \verbatim
+*>          UPLO is CHARACTER*1
+*>          = 'U':  A is upper triangular;
+*>          = 'L':  A is lower triangular.
+*> \endverbatim
+*>
+*> \param[in] DIAG
+*> \verbatim
+*>          DIAG is CHARACTER*1
+*>          = 'N':  A is non-unit triangular;
+*>          = 'U':  A is unit triangular.
+*> \endverbatim
+*>
+*> \param[in] N
+*> \verbatim
+*>          N is INTEGER
+*>          The order of the matrix A.  N >= 0.
+*> \endverbatim
+*>
+*> \param[in,out] A
+*> \verbatim
+*>          A is DOUBLE PRECISION array, dimension (LDA,N)
+*>          On entry, the triangular matrix A.  If UPLO = 'U', the
+*>          leading N-by-N upper triangular part of the array A contains
+*>          the upper triangular matrix, and the strictly lower
+*>          triangular part of A is not referenced.  If UPLO = 'L', the
+*>          leading N-by-N lower triangular part of the array A contains
+*>          the lower triangular matrix, and the strictly upper
+*>          triangular part of A is not referenced.  If DIAG = 'U', the
+*>          diagonal elements of A are also not referenced and are
+*>          assumed to be 1.
+*>          On exit, the (triangular) inverse of the original matrix, in
+*>          the same storage format.
+*> \endverbatim
+*>
+*> \param[in] LDA
+*> \verbatim
+*>          LDA is INTEGER
+*>          The leading dimension of the array A.  LDA >= max(1,N).
+*> \endverbatim
+*>
+*> \param[out] INFO
+*> \verbatim
+*>          INFO is INTEGER
+*>          = 0: successful exit
+*>          < 0: if INFO = -i, the i-th argument had an illegal value
+*>          > 0: if INFO = i, A(i,i) is exactly zero.  The triangular
+*>               matrix is singular and its inverse can not be computed.
+*> \endverbatim
+*
+*  Authors:
+*  ========
+*
+*> \author Univ. of Tennessee
+*> \author Univ. of California Berkeley
+*> \author Univ. of Colorado Denver
+*> \author NAG Ltd.
+*
+*> \date December 2016
+*
+*> \ingroup doubleOTHERcomputational
+*
+*  =====================================================================
+      SUBROUTINE DTRTRI( UPLO, DIAG, N, A, LDA, INFO )
+*
+*  -- LAPACK computational routine (version 3.7.0) --
+*  -- LAPACK is a software package provided by Univ. of Tennessee,    --
+*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
+*     December 2016
+*
+*     .. Scalar Arguments ..
+      CHARACTER          DIAG, UPLO
+      INTEGER            INFO, LDA, N
+*     ..
+*     .. Array Arguments ..
+      DOUBLE PRECISION   A( LDA, * )
+*     ..
+*
+*  =====================================================================
+*
+*     .. Parameters ..
+      DOUBLE PRECISION   ONE, ZERO
+      PARAMETER          ( ONE = 1.0D+0, ZERO = 0.0D+0 )
+*     ..
+*     .. Local Scalars ..
+      LOGICAL            NOUNIT, UPPER
+      INTEGER            J, JB, NB, NN
+*     ..
+*     .. External Functions ..
+      LOGICAL            LSAME
+      INTEGER            ILAENV
+      EXTERNAL           LSAME, ILAENV
+*     ..
+*     .. External Subroutines ..
+      EXTERNAL           DTRMM, DTRSM, DTRTI2, XERBLA
+*     ..
+*     .. Intrinsic Functions ..
+      INTRINSIC          MAX, MIN
+*     ..
+*     .. Executable Statements ..
+*
+*     Test the input parameters.
+*
+      INFO = 0
+      UPPER = LSAME( UPLO, 'U' )
+      NOUNIT = LSAME( DIAG, 'N' )
+      IF( .NOT.UPPER .AND. .NOT.LSAME( UPLO, 'L' ) ) THEN
+         INFO = -1
+      ELSE IF( .NOT.NOUNIT .AND. .NOT.LSAME( DIAG, 'U' ) ) THEN
+         INFO = -2
+      ELSE IF( N.LT.0 ) THEN
+         INFO = -3
+      ELSE IF( LDA.LT.MAX( 1, N ) ) THEN
+         INFO = -5
+      END IF
+      IF( INFO.NE.0 ) THEN
+         CALL XERBLA( 'DTRTRI', -INFO )
+         RETURN
+      END IF
+*
+*     Quick return if possible
+*
+      IF( N.EQ.0 )
+     $   RETURN
+*
+*     Check for singularity if non-unit.
+*
+      IF( NOUNIT ) THEN
+         DO 10 INFO = 1, N
+            IF( A( INFO, INFO ).EQ.ZERO )
+     $         RETURN
+   10    CONTINUE
+         INFO = 0
+      END IF
+*
+*     Determine the block size for this environment.
+*
+      NB = ILAENV( 1, 'DTRTRI', UPLO // DIAG, N, -1, -1, -1 )
+      IF( NB.LE.1 .OR. NB.GE.N ) THEN
+*
+*        Use unblocked code
+*
+         CALL DTRTI2( UPLO, DIAG, N, A, LDA, INFO )
+      ELSE
+*
+*        Use blocked code
+*
+         IF( UPPER ) THEN
+*
+*           Compute inverse of upper triangular matrix
+*
+            DO 20 J = 1, N, NB
+               JB = MIN( NB, N-J+1 )
+*
+*              Compute rows 1:j-1 of current block column
+*
+               CALL DTRMM( 'Left', 'Upper', 'No transpose', DIAG, J-1,
+     $                     JB, ONE, A, LDA, A( 1, J ), LDA )
+               CALL DTRSM( 'Right', 'Upper', 'No transpose', DIAG, J-1,
+     $                     JB, -ONE, A( J, J ), LDA, A( 1, J ), LDA )
+*
+*              Compute inverse of current diagonal block
+*
+               CALL DTRTI2( 'Upper', DIAG, JB, A( J, J ), LDA, INFO )
+   20       CONTINUE
+         ELSE
+*
+*           Compute inverse of lower triangular matrix
+*
+            NN = ( ( N-1 ) / NB )*NB + 1
+            DO 30 J = NN, 1, -NB
+               JB = MIN( NB, N-J+1 )
+               IF( J+JB.LE.N ) THEN
+*
+*                 Compute rows j+jb:n of current block column
+*
+                  CALL DTRMM( 'Left', 'Lower', 'No transpose', DIAG,
+     $                        N-J-JB+1, JB, ONE, A( J+JB, J+JB ), LDA,
+     $                        A( J+JB, J ), LDA )
+                  CALL DTRSM( 'Right', 'Lower', 'No transpose', DIAG,
+     $                        N-J-JB+1, JB, -ONE, A( J, J ), LDA,
+     $                        A( J+JB, J ), LDA )
+               END IF
+*
+*              Compute inverse of current diagonal block
+*
+               CALL DTRTI2( 'Lower', DIAG, JB, A( J, J ), LDA, INFO )
+   30       CONTINUE
+         END IF
+      END IF
+*
+      RETURN
+*
+*     End of DTRTRI
+*
+      END

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -1137,9 +1137,10 @@ lp: do while (.not. success)
     type( nlls_workspace ), intent(inout) :: w
     type( nlls_options ), intent(in) :: options
     type( nlls_inform ), intent(inout) :: inform
-
-    logical :: bad_allocate=.false.
-    integer :: ierr_dummy=0
+    logical :: bad_allocate
+    integer :: ierr_dummy
+    bad_allocate = .false.
+    ierr_dummy = 0
 
     ! copy resvec if needed
     if (allocated(w%resvec)) then

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -97,7 +97,7 @@ contains
 !  Authors: RAL NA Group (Iain Duff, Nick Gould, Jonathan Hogg, Tyrone Rees,
 !                         Jennifer Scott)
 !  -----------------------------------------------------------------------------
-
+    Use nag_export_mod, Only: calculate_covm
 !   Dummy arguments
     implicit none
 
@@ -166,6 +166,12 @@ contains
      inform%status = NLLS_ERROR_MAXITS
 
 100 continue
+
+     ! If requested, save covariance matrix or variance vector or J^T*J
+     if (options%save_covm /= 0) then
+       ! Does not fail, if errors ocurr inform%covm (or %var) is not allocated
+       call calculate_covm(m, n, w%j, inform, options, options%save_covm)
+     end if
 
      call nlls_finalize(w,options,inform)
      If (inform%status /= 0) then

--- a/libRALFit/src/ral_nlls_printing.f90
+++ b/libRALFit/src/ral_nlls_printing.f90
@@ -96,6 +96,9 @@
       Write (adj,Fmt=99999) 'nlls_method'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99997) adjustl(adj), options%nlls_method
+      Write (adj,Fmt=99999) 'allow_fallback_method'
+      nrec = nrec + 1
+      Write (rec(nrec),Fmt=99996) adjustl(adj), options%allow_fallback_method
       Write (adj,Fmt=99999) 'lls_solver'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99997) adjustl(adj), options%lls_solver
@@ -114,9 +117,6 @@
       Write (adj,Fmt=99999) 'stop_s'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99998) adjustl(adj), options%stop_s
-      Write (adj,Fmt=99999) 'allow_fallback_method'
-      nrec = nrec + 1
-      Write (rec(nrec),Fmt=99996) adjustl(adj), options%allow_fallback_method
       Write (adj,Fmt=99999) 'relative_tr_radius'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99997) adjustl(adj), options%relative_tr_radius
@@ -242,7 +242,7 @@
       Write (adj,Fmt=99999) 'box_nfref_max'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99997) adjustl(adj), options%box_nfref_max
-      Write (adj,Fmt=99999) 'box_ntrfail'
+      Write (adj,Fmt=99999) 'box_gamma'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99998) adjustl(adj), options%box_gamma
       Write (adj,Fmt=99999) 'box_decmin'
@@ -302,6 +302,9 @@
       Write (adj,Fmt=99999) 'box_linesearch_type'
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99997) adjustl(adj), options%box_linesearch_type
+      Write (adj,Fmt=99999) 'save_covm'
+      nrec = nrec + 1
+      Write (rec(nrec),Fmt=99997) adjustl(adj), options%save_covm
 
       nrec = nrec + 1
       Write (rec(nrec),Fmt=99994)

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -368,7 +368,7 @@ module ral_nlls_workspaces
      Integer       :: box_linesearch_type = 1
 !       Save covariance matrix type
 !         0: None
-!         1: C = inv(sigma * J^T J)
+!         1: C = sigma^2 * inv(J^T J)
 !         2: only diagonal of C
 !         3: only J^T J
      Integer       :: save_covm = 0

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -487,6 +487,10 @@ module ral_nlls_workspaces
      Integer :: f_eval_pg = 0
      Integer :: g_eval_pg = 0
 
+! COVARIANCE MATRIX (VARIANCE vector or J^T*J)
+     real(wp), allocatable :: cov(:,:)
+     real(wp), allocatable :: var(:)
+
   END TYPE nlls_inform
 
   type, public :: params_base_type

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -366,6 +366,13 @@ module ral_nlls_workspaces
      Integer       :: box_ls_step_maxit = 20
 !    LS type: 1 => Dennis-Schnabel; 2 => Hager-Zhang
      Integer       :: box_linesearch_type = 1
+!       Save covariance matrix type
+!         0: None
+!         1: C = inv(sigma * J^T J)
+!         2: only diagonal of C
+!         3: only J^T J
+     Integer       :: save_covm = 0
+
   END TYPE nlls_options
 
 !  - - - - - - - - - - - - - - - - - - - - - - -

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -1173,6 +1173,8 @@ program nlls_test
      call error_message_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
+     call covariance_matrix_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
 
      ! Report back results....
 


### PR DESCRIPTION
Add support to build and export the covariance matrix, alternatively the variance vector or the approximation to the Hessian (J^T*J)

This branch closes #92 

New `nlls_options` object added (1)  `options%save_covm=T/F`
New `nlls_inform` objects added (2) `inform%cov(:,:)` and `inform%var(:)`

Test were added to `example_module` but should not create diffs wrt `master`