### PR TITLE
95 fix cjac

### DIFF
--- a/anvil_tests.sh
+++ b/anvil_tests.sh
@@ -34,7 +34,7 @@ nagfor-debug)
    export CC=gcc
    export F77=nagfor
    export FC=nagfor
-   export FFLAGS="-g -W0,-gline -nan -C=all -C=undefined -u -ieee=full -kind=unique"
+   export FFLAGS="-g -nan -C=all -C=undefined -u -ieee=full -kind=unique"
 esac
 
 

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -73,7 +73,7 @@ module ral_nlls_internal
     public :: test_convergence, calculate_rho
     public :: solve_LLS, shift_matrix
     public :: dogleg, more_sorensen, generate_scaling, solve_newton_tensor, aint_tr
-    public :: switch_to_quasi_newton, evaltensor_f, evaltensor_J
+    public :: switch_to_quasi_newton
 
 contains
 

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -1015,8 +1015,8 @@ lp: do while (.not. success)
 !   ! Description of columns                                               !
 !   ! * Iter:  current iteration counter valuei                            !
 !   ! * error: objective value (F)                                         !
-!   ! * grad:  norm-two of gradient (JF)                                   !
-!   ! * rel grad: relative gradient norm-two (F/JF)                        !
+!   ! * optim:  norm-two of gradient (JF)                                  !
+!   ! * rel optim: relative gradient norm-two (F/JF)                       !
 !   ! * Delta: TR radius                                                   !
 !   ! * rho: quantity: actual_reduction / predicted_reduction              !
 !   ! * S2IF: flags:                                                       !
@@ -1032,6 +1032,9 @@ lp: do while (.not. success)
 !   !       indicate information is not available.                         !
 !   ! * inn it: inner iteration cummulative counter                        !
 !   ! * step: size of last step                                            !
+!   ! * loop: trust region loop exit status                                !
+!   ! * LS: iteration counter for linesearch algorithms                    !
+!   ! * tau: the projection factor over the constraints |P(X+d)-X| / |d|   !
 !   !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
     prncnt = inform%inner_iter + w%iter
     If ( options%model == 4 ) then

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -73,7 +73,7 @@ module ral_nlls_internal
     public :: test_convergence, calculate_rho
     public :: solve_LLS, shift_matrix
     public :: dogleg, more_sorensen, generate_scaling, solve_newton_tensor, aint_tr
-    public :: switch_to_quasi_newton
+    public :: switch_to_quasi_newton, evaltensor_f, evaltensor_J
 
 contains
 

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -4151,9 +4151,7 @@ lp:    do i = 1, w%tensor_options%maxit
      end subroutine calculate_sHs
 
      Recursive subroutine evaltensor_J(status, n, m, s, J, params)
-       ! TODO Add tests for this routine: check for 
-       ! * params%extra = 0, 1, 2
-       ! * params%Fortran_Jacobian = T, F
+
        Implicit None
        integer, intent(out) :: status
        integer, intent(in)  :: n

--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -4214,17 +4214,6 @@ lp:    do i = 1, w%tensor_options%maxit
             end if
           end if
 
-!         print *, 'JT = '
-!         if (params%Fortran_Jacobian) then
-!           Do jj = 1, n
-!             Write( *, '(*(F12.7,2X))') J( (jj-1)*m + 1 : jj*m )
-!           End Do
-!         else
-!           Do jj = 1, n
-!             Write( *, '(*(F12.7,2X))') J( (/ (kk, kk=jj,m*n,n) /) )
-!           End Do
-!         End if
-
        end select
      end subroutine evaltensor_J
 

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -537,6 +537,7 @@ module ral_nlls_workspaces
      procedure( eval_hp_type ), pointer, nopass :: eval_HP
      logical :: eval_hp_provided = .false.
      class( params_base_type ), pointer :: parent_params
+     logical :: Fortran_Jacobian
      type( tenJ_type ), pointer :: tenJ
   end type tensor_params_type
 

--- a/libRALFit/src/ral_nlls_workspaces.f90
+++ b/libRALFit/src/ral_nlls_workspaces.f90
@@ -1312,6 +1312,9 @@ contains
     end if
 
     w%allocated = .true.
+    ! zero-out y_hardcase
+    w%y_hardcase(:,:) = 0.0_wp
+
 
 100 continue
 

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -1946,7 +1946,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
         fails = fails + 1
      end if
      ! check answer
-     call mult_J(J,n,m,d,Jd)
+     call mult_J(J,n,m,d,Jd,.True.)
      normerror = norm2(Jd + f)
      if ( normerror > 1.0e-12_wp ) then
         ! wrong answer, as data chosen to fit
@@ -2258,7 +2258,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      
      x = 1.0_wp
      J = [ 1.0 , 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
-     call mult_J(J,m,n,x,Jx)
+     call mult_J(J,m,n,x,Jx,.True.)
      if ( norm2( Jx - [16.0, 20.0 ] ) > 1e-12) then
         write(*,*) 'error :: mult_J test failed'
         fails = fails + 1
@@ -2286,7 +2286,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      
      x = 1.0_wp
      J = [ 1.0 , 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
-     call mult_Jt(J,n,m,x,Jtx)
+     call mult_Jt(J,n,m,x,Jtx,.True.)
      if ( norm2( Jtx - [10.0, 26.0 ] ) > 1e-12) then
         write(*,*) 'error :: mult_Jt test failed'
         fails = fails + 1

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -3304,5 +3304,116 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 10000 Format (1X,I3,3(3X,Es17.10e2),1X,A6)
 10001 Format (1X,A,1X,A6)
 end subroutine covariance_matrix_tests
-   
+
+subroutine evaltensor_tests(options, fails)
+  implicit none
+  type( nlls_options ), intent(inout) :: options
+  integer, intent(out) :: fails
+
+  type(nlls_inform) :: inform
+  integer :: status, status_f, status_c, n, m, iloop, jloop
+  real(wp), allocatable :: s(:)
+  real(wp), allocatable :: J(:), J_c(:), f(:), f_c(:)
+  real(wp) :: norm_J_diff, norm_f_diff
+  type(user_type), target :: params
+  type( nlls_workspace), target :: work 
+  type( nlls_workspace ), Target :: iw
+!  Type( tenJ_type ), pointer :: tenJ
+
+  fails = 0
+!      Link the inner_workspace to the main workspace
+  work%iw_ptr => iw
+!      Self reference for inner workspace so recursive call does not fail
+  iw%iw_ptr => iw
+  
+  n = 2
+  m = 67
+
+  options%model = 4
+  call setup_workspaces(work,n,m,options,inform)
+  
+  allocate(J(n*m),J_c(n*m),s(m),f(m),f_c(m))
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%X(1:n) = 1.0_wp
+
+  call generate_data_example(params)
+
+  call eval_f(status, n, m, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%X(1:n), &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%f(1:m), params)
+
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%Delta = 10.0_wp
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%eval_HF => eval_H
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%parent_params => params
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%tenJ => work%tenJ
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%eval_hp_provided = .false.
+  
+  ! check the fortran jacobian
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%Fortran_Jacobian = .true.
+  call eval_J ( status_f, n, m, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%X(1:n), &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%J(1:n*m), &
+       params) 
+  if (status_f .ne. 0) then
+     write(*,*) 'eval_j failed'
+     fails = fails + 1
+  end if
+  call evaltensor_f(status, n, m, s, f, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams)
+  if (status .ne. 0) then
+     write(*,*) 'evaltensor_J call (fortran) failed'
+     fails = fails + 1
+  end if
+  call evaltensor_J(status, n, m, s, J, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams)
+  if (status .ne. 0) then
+     write(*,*) 'evaltensor_J call (fortran) failed'
+     fails = fails + 1
+  end if
+  
+  ! check the c jacobian
+  work%calculate_step_ws%solve_newton_tensor_ws%tparams%Fortran_Jacobian = .false.
+  call eval_J_c ( status_c, n, m, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%X(1:n), &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams%J(1:n*m), &
+       params) 
+  if (status_c .ne. 0) then
+     write(*,*) 'eval_j_c failed'
+     fails = fails + 1
+  end if
+  call evaltensor_f(status, n, m, s, f_c, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams)
+  if (status .ne. 0) then
+     write(*,*) 'evaltensor_J call (fortran) failed'
+     fails = fails + 1
+  end if
+  
+  norm_J_diff = norm2(f - f_c)
+  if (norm_f_diff > 1e-10) then
+     write(*,*) 'C and Fortran function evaluations are different'
+     write(*,*) 'the difference is ', norm_f_diff
+     fails= fails+1
+  end if
+
+  call evaltensor_J(status, n, m, s, J_c, &
+       work%calculate_step_ws%solve_newton_tensor_ws%tparams)
+  if (status .ne. 0) then
+     write(*,*) 'evaltensor_J call (c) failed'
+     fails = fails + 1
+  end if
+
+  do iloop  = 1, m
+     do jloop  = 1, n
+        norm_J_diff = norm_J_diff + (J_c((iloop-1)*n +jloop)-J((jloop-1)*m+iloop))**2
+     end do
+  end do
+  norm_J_diff = sqrt(norm_J_diff)
+  if (norm_J_diff > 1e-10) then
+     write(*,*) 'C and Fortran Jacobians are different'
+     write(*,*) 'the difference is ', norm_J_diff
+     fails= fails+1
+  end if
+ 
+  
+end subroutine evaltensor_tests
+
  end module example_module

--- a/libRALFit/test/example_module.f90
+++ b/libRALFit/test/example_module.f90
@@ -1202,7 +1202,39 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
            lower_bounds=blx, upper_bounds=bux )
       
      end subroutine solve_basic
+     
+     subroutine solve_basic_c(X,params,options,inform,warm_start,blx,bux)
+       
+       real(wp), intent(inout) :: X(:)
+       !      type( user_type ), intent(inout) :: params
+       Class ( params_base_type ), intent(inout) :: params
+       type( nlls_options ), intent(in) :: options
+       type( nlls_inform ), intent(inout) :: inform
+       Logical, Optional, Intent(In) :: warm_start
+       real(wp), intent(inout),optional :: blx(:), bux(:)
 
+       integer :: n, m
+       
+       n = 2 
+       m = 67
+       
+       If (present(warm_start)) Then
+         If(.Not. warm_start) Then
+           X(1) = 1.0
+           X(2) = 2.0
+         End If
+       Else
+         X(1) = 1.0
+         X(2) = 2.0
+      End if
+      call nlls_solve(n, m, X,                         &
+           eval_F, eval_J_c, eval_H, params,  &
+           options, inform,                 &
+           lower_bounds=blx, upper_bounds=bux )
+      
+    end subroutine solve_basic_c
+
+     
      subroutine dogleg_tests(options,fails)
        
        type( nlls_options ), intent(inout) :: options       

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -124,7 +124,7 @@ program nlls_test
               if ( c_status%iter == status%iter ) then
                  resvec_error = norm2(c_status%resvec(1:c_status%iter+1) - &
                       status%resvec(1:status%iter+1))
-                 if (resvec_error > 1e-10) then
+                 if (resvec_error > 1e-8) then
                     write(*,*) 'error: fortran and c jacobians'
                     write(*,*) 'have different resvecs'
                     write(*,*) '||r_f - r_c|| = ', resvec_error

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -122,10 +122,12 @@ program nlls_test
               ! check that the results are consistent with
               ! both c and fortran jacobians
               if ( c_status%iter == status%iter ) then
-                 if (norm2(c_status%resvec(1:c_status%iter+1) - &
-                      status%resvec(1:status%iter+1)) > 1e-16) then
+                 resvec_error = norm2(c_status%resvec(1:c_status%iter+1) - &
+                      status%resvec(1:status%iter+1))
+                 if (resvec_error > 1e-10) then
                     write(*,*) 'error: fortran and c jacobians'
                     write(*,*) 'have different resvecs'
+                    write(*,*) '||r_f - r_c|| = ', resvec_error
                     no_errors_main = no_errors_main + 1
                  end if
               else

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -1217,6 +1217,9 @@ program nlls_test
      call covariance_matrix_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
+     call evaltensor_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
+
      ! Report back results....
 
      if (no_errors_helpers == 0) then


### PR DESCRIPTION
# WORK IN PROGRESS


# Updates related to `options%Fortran_Jacobian`

This branch closes #95

This is the first proposal to update parts of the code that handle
Matrix-Vector Products or other related operations pertaining to the
Jacobian (only for the case where it is provided as Jacobian Transpose
via row-major, using the option `options%Fortran_Jacobian = .False.`)

 * Forces `mult_J` and `mult_Jt` to specify the leading dimension of J,
   the optional parameter `options` is replaced by a mandatory lofical
   parameter `Fortran_Jacobian`

 * `evaltensor_f` and `evaltensor_J` require to know the leading
   dimension of J and for that `tensor_params` type is extended with a
   new node `Fortran_Jacobian` that is set at the entry of the recursive
   call to `nlls_iterate` in `solve_newton_tensor()`

 * `evaltensor_J` now branches on the Jacobian's leading dimension

 * Numerical artifacts should be kept minimal, initial test shows
   rubbish creping arount 10^-7 for the Lanczos3 example with default
   options

 * Add a mandatory logical flag to `solve_LLS` so to consider the
   leading dimension of the Jacobian.

 * Add a test to make sure the LLS is solving the right problem

# Missing test to be added
 - [ ]  test `evaltensor_J` and check that it returns the correct array for `params%extra=0,1,2` and `params%Fortran_Jacobian=T/F`
 - [x]  Full code-path tests should be duplicated with `opt%Fortran_Jacobian = T/F` and compared.

