### PR TITLE
MInor updates for `evaltensor_J`

### DIFF
--- a/libRALFit/src/ral_nlls_internal.f90
+++ b/libRALFit/src/ral_nlls_internal.f90
@@ -73,7 +73,7 @@ module ral_nlls_internal
     public :: test_convergence, calculate_rho
     public :: solve_LLS, shift_matrix
     public :: dogleg, more_sorensen, generate_scaling, solve_newton_tensor, aint_tr
-    public :: switch_to_quasi_newton
+    public :: switch_to_quasi_newton, evaltensor_J
 
 contains
 
@@ -4158,6 +4158,7 @@ lp:    do i = 1, w%tensor_options%maxit
        real(wp), dimension(*), intent(out)   :: J
        class( params_base_type ), intent(inout) :: params
        integer :: ii, jj, kk, offset_j, offset_pj
+       real(wp) :: v
        ! Add default return value for status
        status = 0
        ! The function we need to return is
@@ -4183,36 +4184,47 @@ lp:    do i = 1, w%tensor_options%maxit
             end do
             if (params%extra == 1) then
                ! we're passing in the regularization via the function/Jacobian
+               v = sqrt(1.0_wp/params%Delta)
                do ii = 1,n ! loop over the columns...
-                  J(m*(ii-1) + params%m + ii) = sqrt(1.0_wp/params%Delta)
+                  J(m*(ii-1) + params%m + ii) = v
                end do
             elseif (params%extra == 2) then
+               v = sqrt( (params%p)/(2.0_wp * params%Delta) ) *                &
+                     (norm2(s(1:n))**( (params%p/2.0_wp) - 2.0_wp))
                do ii = 1, n ! loop over the columns....
-                  J(m*ii) = sqrt( (params%p)/(2.0_wp * params%Delta) ) * &
-                                        (norm2(s(1:n))**( (params%p/2.0_wp) - 2.0_wp)) * &
-                                        s(ii)
+                  J(m*ii) =  v * s(ii)
                end do
             end if
           else
             ! Jacobian is provided row-wise
             Do jj = 1, params%m
-              J( ((jj-1) * n + 1) : jj*n ) = params%J( ((jj-1) * n + 1) : jj*n ) + params%tenJ%Hs(:,jj)
+              ! avoid auto allocation
+              ! J( (jj-1)*n+1 : jj*n ) = params%J( (jj-1)*n+1 : jj*n ) + params%tenJ%Hs(:,jj)
+              Do kk = 1, n
+                J( (jj-1)*n+kk ) = params%J( (jj-1)*n+kk ) + params%tenJ%Hs(kk,jj)
+              End Do
             End Do
             if (params%extra == 1) then
                ! we're passing in the regularization via the function/Jacobian
                ! Update the diagonal of the last nxn block
+               v =  sqrt(1.0_wp/params%Delta)
                do ii = 1,n ! offset by params%m*n and loop over the rows...
-                  J(params%m*n + n*(ii-1) + ii) = sqrt(1.0_wp/params%Delta)
+                  J(params%m*n + n*(ii-1) + ii) = v
                end do
             elseif (params%extra == 2) then
               ! Update last column of J
-                J((m-1)*n+1 : m*n) = sqrt( (params%p)/(2.0_wp * params%Delta) ) * &
-                                        (norm2(s(1:n))**( (params%p/2.0_wp) - 2.0_wp)) * &
-                                        s(1:n)
+              v = sqrt( (params%p)/(2.0_wp * params%Delta) ) *                 &
+                    (norm2(s(1:n))**( (params%p/2.0_wp) - 2.0_wp))
+              ! avoid auto allocation
+              ! J((m-1)*n+1 : m*n) = v * s(1:n)
+              Do kk = 1, n
+                J((m-1)*n+kk) = v * s(kk)
+              End Do
             end if
           end if
 
        end select
+
      end subroutine evaltensor_J
 
      Recursive subroutine evaltensor_HF(status, n, m, s, f, HF, params)

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -1167,6 +1167,8 @@ program nlls_test
      call covariance_matrix_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
+     call evaltensor_J_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
      ! Report back results....
 
      if (no_errors_helpers == 0) then


### PR DESCRIPTION
This branch fixed autoallocations inside `evaltensor_J` and also adds:

 * 6 tests to the call-back `evaltensor_J` which checks `params%extra` and compares J and JT using `params%fortran_Jacobian`=`options%fortran_Jacobian`

 * 2 loops in assignments to avoid auto-allocations (due to `j(*)`)

* avoids recalculating the same value inside assignment loops (adds scalar `v`)