### PR TITLE
initialize status for fd_jacobian

### DIFF
--- a/libRALFit/src/ral_nlls_fd.f90
+++ b/libRALFit/src/ral_nlls_fd.f90
@@ -556,6 +556,8 @@ Contains
 
       Continue
 
+      status = 0
+
       perturbation = iparams%options%fd_step
       Fortran_Jacobian = iparams%options%Fortran_Jacobian
 

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -1136,7 +1136,7 @@ program nlls_test
      bux(1:n) = 1.0
      call solve_basic(X,params,options,status,blx=blx,bux=bux)
      if ( .Not. ( status%status == 0 ) ) then
-        write(*,*) 'Error: [id:6] check_derivatives: unexpected status value'
+        write(*,*) 'Error: [id:6] check_derivatives: unexpected status value: ', status%status
         if ( status%status == NLLS_ERROR_FROM_EXTERNAL ) then
             write(*,*) 'external name: ', status%external_name
             write(*,*) 'external return: ', status%external_return

--- a/libRALFit/test/nlls_test.f90
+++ b/libRALFit/test/nlls_test.f90
@@ -1137,6 +1137,10 @@ program nlls_test
      call solve_basic(X,params,options,status,blx=blx,bux=bux)
      if ( .Not. ( status%status == 0 ) ) then
         write(*,*) 'Error: [id:6] check_derivatives: unexpected status value'
+        if ( status%status == NLLS_ERROR_FROM_EXTERNAL ) then
+            write(*,*) 'external name: ', status%external_name
+            write(*,*) 'external return: ', status%external_return
+        end if
         no_errors_main = no_errors_main + 1
      end if
 


### PR DESCRIPTION
In `fd_jacobian` the status flag was not initialized, when there is no feasible space, fd can't evaluate f and should return 0, in some cases status is not initialized and this is not always caught.