### PR TITLE
Refactors to use unified linear solver interface

### DIFF
--- a/libRALFit/doc/common/errors.rst
+++ b/libRALFit/doc/common/errors.rst
@@ -40,6 +40,8 @@ Possible values are:
       -  One or more elements in the Jacobian appear to be wrong
     * - -20
       -  Weights vector must be sufficiently positive
+    * - -21
+      -  Unsupported LLS solver (``lls_solver``) specified in options. 
     * - -101
       -  Unsupported model in dogleg (``nlls_method=1``).
     * - -201

--- a/libRALFit/doc/common/options.rst
+++ b/libRALFit/doc/common/options.rst
@@ -84,6 +84,8 @@
 
 .. |scale_require_increase| replace:: specifies whether or not to require :math:`{\tt D}_{i,i}` to increase before updating it.
 
+.. |lls_solver| replace:: specifies which linear least squares solver to use internally.
+
 .. |more_sorensen_maxits| replace:: if ``nlls_method = 3``, specifies the maximum number of iterations allowed in the More-Sorensen method.
 
 .. |more_sorensen_shift| replace:: if ``nlls_method = 3``, specifies the shift to be used in the More-Sorensen method. 

--- a/libRALFit/src/CMakeLists.txt
+++ b/libRALFit/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(source_files
     nag_export_mod.F90
     ral_nlls_fd.F90
     ral_nlls_internal.F90
+    ral_nlls_linear.F90
     ral_nlls.F90
     ral_nlls_ciface.F90
     CACHE INTERNAL "source_files" FORCE)
@@ -92,6 +93,8 @@ function(generate_ral_nlls_modules precision obj_list)
     "NAG_EXPORT_MOD_${precision}" "RAL_NLLS_WORKSPACES_${precision}")
   add_dependencies("RAL_NLLS_${precision}" "RAL_NLLS_INTERNAL_${precision}")
   add_dependencies("RAL_NLLS_CIFACE_${precision}" "RAL_NLLS_${precision}")
+  add_dependencies("RAL_NLLS_INTERNAL_${precision}" "RAL_NLLS_LINEAR_${precision}")
+  add_dependencies("RAL_NLLS_LINEAR_${precision}" "RAL_NLLS_WORKSPACES_${precision}")
 
   # Replicate tree to be compatible with Ninja
   target_link_libraries("RAL_NLLS_DTRS_${precision}" "RAL_NLLS_TYPES_${precision}"
@@ -113,6 +116,8 @@ function(generate_ral_nlls_modules precision obj_list)
     "NAG_EXPORT_MOD_${precision}" "RAL_NLLS_WORKSPACES_${precision}")
   target_link_libraries("RAL_NLLS_${precision}" "RAL_NLLS_INTERNAL_${precision}")
   target_link_libraries("RAL_NLLS_CIFACE_${precision}" "RAL_NLLS_${precision}")
+  target_link_libraries("RAL_NLLS_INTERNAL_${precision}" "RAL_NLLS_LINEAR_${precision}")
+  target_link_libraries("RAL_NLLS_LINEAR_${precision}" "RAL_NLLS_WORKSPACES_${precision}")
 endfunction()
 
 # Post ################

--- a/libRALFit/src/ral_nlls_internal.F90
+++ b/libRALFit/src/ral_nlls_internal.F90
@@ -1460,6 +1460,7 @@ lp: do while (.not. success)
                         options, inform)
                 end if
                 subproblem_method = 2 ! try aint next
+
                 call dogleg(J,f,hf,g,n,m,Delta,d,norm_S_d, &
                      options,inform,w%dogleg_ws)
                 if (inform%status == 0) subproblem_success = .true.
@@ -1976,9 +1977,9 @@ lp: do while (.not. success)
        ! Solve (A+lam*B)x=-v:
        ! 1. we can use w%B to actually store A + lam * B
         w%B(:,:) = A(:,:)
-        w%p1(:) = -v(:)
         Do i = 1, n
           w%B(i,i) = w%B(i,i) + lam
+          w%p1(i) = -v(i)
         End Do
         call solve_LLS_nocopy(w%B, w%p1, n, n, inform, w%solve_LLS_ws, options, pd)
         if (inform%status /= 0) goto 100
@@ -2212,7 +2213,7 @@ lp:  do i = 1, options%more_sorensen_maxits
              Write(rec(1), Fmt=5040)
              Call Printmsg(5,.False.,options,1,rec)
            End If
-           goto 100 
+           goto 100
         end if
 
         w%q(:) = d ! w%q = R'\d
@@ -2557,9 +2558,8 @@ lp:  do i = 1, options%more_sorensen_maxits
         elseif (region == 3) then
            call shift_matrix(A,sigma + sigma_shift,w%AplusSigma,n)
            ! solve (A + sigma)d = -v
-           w%LtL(1:n,1:n) = w%AplusSigma(1:n,1:n)
            d(1:n) = -v(1:n)
-           call solve_LLS_nocopy(w%LtL,d,n,n,inform,w%lls_ws,options,.true.) 
+           call solve_LLS_nocopy(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.) 
 
            if (inform%status == 0) then
               region = 2
@@ -3445,7 +3445,6 @@ lp:  do i = 1, options%more_sorensen_maxits
          call PREC(gemv)('T',m,n,alpha,J,max(1,m),x,1,beta,Jtx,1)
        End If
      end subroutine mult_Jt
-
 
      subroutine scale_J_by_weights(J,n,m,weights,options)
        Implicit None

--- a/libRALFit/src/ral_nlls_internal.F90
+++ b/libRALFit/src/ral_nlls_internal.F90
@@ -14,7 +14,7 @@ module MODULE_PREC(ral_nlls_internal)
   Use MODULE_PREC(ral_nlls_printing)
   Use MODULE_PREC(ral_nlls_bounds)
   Use MODULE_PREC(ral_nlls_types), Only: PREC(nrm2), PREC(dot)
-  use MODULE_PREC(ral_nlls_linear), only: solve_LLS, solve_LLS_nocopy
+  use MODULE_PREC(ral_nlls_linear), only: solve_LLS
 
   implicit none
 
@@ -1805,7 +1805,7 @@ lp: do while (.not. success)
         ! linear model...
         w%solve_LLS_ws%Jlls = reshape(J, [n,m])
         w%solve_LLS_ws%temp(1:m) = f(1:m)
-        call solve_LLS_nocopy(w%solve_LLS_ws%Jlls,w%solve_LLS_ws%temp,n,m,inform,w%solve_LLS_ws,options,.false.)
+        call solve_LLS(w%solve_LLS_ws%Jlls,w%solve_LLS_ws%temp,n,m,inform,w%solve_LLS_ws,options,.false.)
         if ( inform%status /= 0 ) goto 100
         w%d_gn = -w%solve_LLS_ws%temp(1:n)
      case default
@@ -1900,7 +1900,7 @@ lp: do while (.not. success)
 
      w%LtL(:, :) = A(:, :)
      w%p0(:) = -v(:)
-     call solve_LLS_nocopy(w%LtL,w%p0,n,n,inform,w%solve_LLS_ws,options,pd)
+     call solve_LLS(w%LtL,w%p0,n,n,inform,w%solve_LLS_ws,options,pd)
      if (inform%status /= 0) goto 100
 
 
@@ -1960,7 +1960,7 @@ lp: do while (.not. success)
         w%M0_small(:,:) = A(:,:) + lam*w%B(:,:) + w%M1_small
         ! solve Hq + g = 0 for q
         w%q(:) = -v(:)
-        call solve_LLS_nocopy(w%M0_small, w%q, n, n, inform, w%solve_LLS_ws, options, pd)
+        call solve_LLS(w%M0_small, w%q, n, n, inform, w%solve_LLS_ws, options, pd)
         if (inform%status /= 0) goto 100
 
         ! find max eta st ||q + eta v(:,1)||_B = Delta
@@ -1981,7 +1981,7 @@ lp: do while (.not. success)
           w%B(i,i) = w%B(i,i) + lam
           w%p1(i) = -v(i)
         End Do
-        call solve_LLS_nocopy(w%B, w%p1, n, n, inform, w%solve_LLS_ws, options, pd)
+        call solve_LLS(w%B, w%p1, n, n, inform, w%solve_LLS_ws, options, pd)
         if (inform%status /= 0) goto 100
      end if
 
@@ -2099,7 +2099,7 @@ lp: do while (.not. success)
      Else
        ! solve (A+sigma)d = -v
        d(1:n) = -v(1:n)
-       call solve_LLS_nocopy(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
+       call solve_LLS(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
      End If
      if (inform%status == 0) then
         ! A is symmetric positive definite....
@@ -2247,7 +2247,7 @@ lp:  do i = 1, options%more_sorensen_maxits
            call shift_matrix(A,sigma,w%AplusSigma,n)
            ! solve (A + sigma)d = -v 
            d(1:n) = -v(1:n) 
-           call solve_LLS_nocopy(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
+           call solve_LLS(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
         end if
         if (inform%status /= 0) goto 100
 
@@ -2381,7 +2381,7 @@ lp:  do i = 1, options%more_sorensen_maxits
            ! solve (A + sigma)d = -v
            w%LtL(1:n,1:n) = w%AplusSigma(1:n,1:n)
            d(1:n) = -v(1:n)
-           call solve_LLS_nocopy(w%LtL,d,n,n,inform,w%lls_ws,options,.true.) 
+           call solve_LLS(w%LtL,d,n,n,inform,w%lls_ws,options,.true.) 
         else
            factorization_done = .false.
         end if
@@ -2559,7 +2559,7 @@ lp:  do i = 1, options%more_sorensen_maxits
            call shift_matrix(A,sigma + sigma_shift,w%AplusSigma,n)
            ! solve (A + sigma)d = -v
            d(1:n) = -v(1:n)
-           call solve_LLS_nocopy(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.) 
+           call solve_LLS(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.) 
 
            if (inform%status == 0) then
               region = 2
@@ -2734,7 +2734,7 @@ lp:  do i = 1, options%more_sorensen_maxits
         call shift_matrix(A,sigma,w%AplusSigma,n)
         ! solve (A + sigma)d = -v 
         d(:) = -v(:)
-        call solve_LLS_nocopy(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
+        call solve_LLS(w%AplusSigma,d,n,n,inform,w%lls_ws,options,.true.)
         if ( inform%status == 0 ) then
             successful_shift = .true.
         else
@@ -2922,7 +2922,7 @@ lp:  do i = 1, options%more_sorensen_maxits
         ! solve (A+sigma)d = -v
         w%LtL(1:n, 1:n) = w%AplusSigma(1:n,1:n)
         d(1:n) = -v(1:n)
-        call solve_LLS_nocopy(w%LtL,d,n,n,inform,w%lls_ws,options,.true.)
+        call solve_LLS(w%LtL,d,n,n,inform,w%lls_ws,options,.true.)
         ! informa%status is passed along, this routine exits here
      else
 !      Feature not yet implemented, this should have been caught in

--- a/libRALFit/src/ral_nlls_internal.F90
+++ b/libRALFit/src/ral_nlls_internal.F90
@@ -1803,7 +1803,7 @@ lp: do while (.not. success)
      select case (options%model)
      case (1)
         ! linear model...
-        w%solve_LLS_ws%Jlls = reshape(J, [n,m])
+        call PREC(lacpy)('A', m, n, J, m, w%solve_LLS_ws%Jlls, m)
         w%solve_LLS_ws%temp(1:m) = f(1:m)
         call solve_LLS(w%solve_LLS_ws%Jlls,w%solve_LLS_ws%temp,n,m,inform,w%solve_LLS_ws,options,.false.)
         if ( inform%status /= 0 ) goto 100

--- a/libRALFit/src/ral_nlls_linear.F90
+++ b/libRALFit/src/ral_nlls_linear.F90
@@ -5,13 +5,14 @@
 module MODULE_PREC(ral_nlls_linear)
   use MODULE_PREC(ral_nlls_workspaces), only: wp, solve_LLS_work, NLLS_inform, &
                                               NLLS_options, NLLS_ERROR_WORKSPACE_ERROR, &
-                                              NLLS_ERROR_FROM_EXTERNAL
+                                              NLLS_ERROR_FROM_EXTERNAL, NLLS_ERROR_BAD_LLS_SOLVER
   implicit none
 
   private
   public :: solve_LLS, solve_LLS_nocopy
 
 contains
+  ! todo: Jacobian argument
   subroutine solve_LLS(A,b,A_out,x,n,m,inform,w,options,pd)
 !  -----------------------------------------------------------------
 !  solve_LLS, a subroutine to solve a linear least squares problem
@@ -19,8 +20,8 @@ contains
 !  Solves the linear least squares problem Ax = b
 !  using the method specified in options%lls_solver
 !  Input:
-!    A         - LHS matrix of the least squares problem (m x n)
-!    b         - The RHS, overwritten with x on output (m x 1)
+!    A         - LHS matrix of the least squares problem 
+!    b         - The RHS, overwritten with x on output 
 !    n         - Number of columns in A
 !    m         - Number of rows in A
 !    inform    - NLLS_inform structure
@@ -28,35 +29,40 @@ contains
 !    w         - workspace structure
 !    pd        - logical, true if A is known to be positive definite
 !  Output:
-!    A_out     - output copy of the original A matrix (m x n)
-!    x         - solution vector (n x 1)
+!    A_out     - output copy of the original A matrix
+!    x         - solution vector 
 !    inform    - NLLS_inform structure
 !    work      - updated workspace structure
 !  -----------------------------------------------------------------
     implicit none
-    real(wp), dimension(:), intent(in) :: A
-    real(wp), dimension(:), intent(in) :: b
-    real(wp), dimension(:), intent(out) :: A_out
-    real(wp), dimension(:), intent(out) :: x
     integer, intent(in) :: n, m
+    real(wp), intent(in) :: A(n,m)
+    real(wp), intent(in) :: b(m)
+    real(wp), intent(out) :: A_out(n,m)
+    real(wp), intent(out) :: x(n)
     type(NLLS_inform), intent(inout) :: inform
     type(NLLS_options), Intent(In) :: options 
     type(solve_LLS_work), intent(inout) :: w
     logical, intent(in) :: pd
 
-    A_out = A
-    x = b
+    real(wp) :: b_out(m)
 
-    call solve_LLS_nocopy(A_out, x, n, m, inform, w, options, pd)
+    A_out = A
+    b_out = b
+
+    call solve_LLS_nocopy(A_out, b_out, n, m, inform, w, options, pd)
+    if (inform%status == 0) then
+      x(1:n) = b_out(1:n)
+    end if
 
   end subroutine solve_LLS
 
   subroutine solve_LLS_nocopy(A, b, n, m, inform, w, options, pd)
 !  linear solver core which overwrites A and b. 
     implicit none
-    real(wp), dimension(:), intent(inout) :: A
-    real(wp), dimension(:), intent(inout) :: b
     integer, intent(in) :: n, m
+    real(wp), dimension(m,n), intent(inout) :: A
+    real(wp), dimension(m), intent(inout) :: b
     type(NLLS_inform), intent(inout) :: inform
     type(NLLS_options), intent(in) :: options 
     type(solve_LLS_work), intent(inout) :: w
@@ -65,33 +71,34 @@ contains
     select case (options%lls_solver) 
       case (1)  ! LAPACK
         if (pd) then
-          call solve_posv(A,b,n,inform,options)
+          call solve_posv(A,b,n,inform)
         else
-          if (.not. w%allocated) then
-            inform%status = NLLS_ERROR_WORKSPACE_ERROR
-            goto 100
+          if (n == m) then
+            call solve_gesv(A,b,n,inform)
+          else
+            if (.not. w%allocated) then
+              inform%status = NLLS_ERROR_WORKSPACE_ERROR
+              goto 100
+            end if
+            call solve_gels(A,b,n,m,inform,w,options)
           end if
-          call solve_gels(A,b,n,m,inform,w,options)
         end if
+      case default
+        inform%status = NLLS_ERROR_BAD_LLS_SOLVER
     end select
 
-    if (inform%external_return /= 0 ) then
-      inform%status = NLLS_ERROR_FROM_EXTERNAL
-    end if 
-
-100   continue
+100 continue
   end subroutine solve_LLS_nocopy
 
   subroutine solve_gels(A,b,n,m,inform,w,options)
 !   Wrapper around LAPACK's ?gels
    implicit none 
-   REAL(wp), DIMENSION(:), INTENT(IN) :: A
-   REAL(wp), DIMENSION(:), INTENT(IN) :: b
+   REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
+   REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
    INTEGER, INTENT(IN) :: n, m
    type(NLLS_inform), INTENT(INOUT) :: inform
    type(NLLS_options), Intent(In) :: options 
 
-   integer, Parameter :: nrhs = 1
    integer :: lwork, lda, ldb
    type( solve_LLS_work ), Intent(inout) :: w
 
@@ -100,12 +107,12 @@ contains
    if (options%Fortran_Jacobian) then
       lda = m
       ldb = max(m,n)
-      call PREC(gels)('N', m, n, nrhs, A, lda, w%temp, ldb, w%work, lwork, &
+      call PREC(gels)('N', m, n, 1, A, lda, b, ldb, w%work, lwork, &
            inform%external_return)
    else
       lda = n
       ldb = max(m,n)
-      call PREC(gels)('T', n, m, nrhs, A, lda, w%temp, ldb, w%work, lwork, &
+      call PREC(gels)('T', n, m, 1, A, lda, b, ldb, w%work, lwork, &
            inform%external_return)
    end if
    if (inform%external_return /= 0 ) then
@@ -115,16 +122,34 @@ contains
 
   end subroutine solve_gels
 
-  subroutine solve_posv(A,b,n,inform,options)
-!   Wrapper around LAPACK's ?posv for positive definite systems
+  subroutine solve_gesv(A,b,n,inform)
+!   Wrapper around LAPACK's ?gesv
     implicit none
-    REAL(wp), DIMENSION(:), INTENT(IN) :: A
-    REAL(wp), DIMENSION(:), INTENT(IN) :: b
+    REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
+    REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
     INTEGER, INTENT(IN) :: n
     type(NLLS_inform), INTENT(INOUT) :: inform
-    type(NLLS_options), Intent(In) :: options
 
-    call PREC(posv)('N', n, 1, A, n, b, n, inform%external_return)
+    ! NB: we never actually use ipiv in the library
+    integer, dimension(n) :: ipiv
+
+    call PREC(gesv)(n, 1, A, n, ipiv, b, n, inform%external_return)
+    if (inform%external_return /= 0 ) then
+       inform%status = NLLS_ERROR_FROM_EXTERNAL
+       inform%external_name = 'lapack_?gesv'
+    end if
+
+  end subroutine solve_gesv
+
+  subroutine solve_posv(A,b,n,inform)
+!   Wrapper around LAPACK's ?posv for positive definite systems
+    implicit none
+    REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
+    REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
+    INTEGER, INTENT(IN) :: n
+    type(NLLS_inform), INTENT(INOUT) :: inform
+
+    call PREC(posv)('L', n, 1, A, n, b, n, inform%external_return)
     if (inform%external_return /= 0 ) then
        inform%status = NLLS_ERROR_FROM_EXTERNAL
        inform%external_name = 'lapack_?posv'

--- a/libRALFit/src/ral_nlls_linear.F90
+++ b/libRALFit/src/ral_nlls_linear.F90
@@ -1,3 +1,7 @@
+! Copyright (c) 2020, The Science and Technology Facilities Council (STFC)
+! All rights reserved.
+! Copyright (C) 2020 Numerical Algorithms Group (NAG). All rights reserved.
+! Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
 ! ral_nlls_linear :: linear solvers for internal use in RALFit
 
 #include "preprocessor.FPP"

--- a/libRALFit/src/ral_nlls_linear.F90
+++ b/libRALFit/src/ral_nlls_linear.F90
@@ -13,11 +13,11 @@ module MODULE_PREC(ral_nlls_linear)
   implicit none
 
   private
-  public :: solve_LLS, solve_LLS_nocopy
+  public :: solve_LLS
 
 contains
   ! todo: Jacobian argument
-  subroutine solve_LLS(A,b,A_out,x,n,m,inform,w,options,pd)
+  subroutine solve_LLS(A, b, n, m, inform, w, options, pd)
 !  -----------------------------------------------------------------
 !  solve_LLS, a subroutine to solve a linear least squares problem
 !  -----------------------------------------------------------------
@@ -25,51 +25,20 @@ contains
 !  using the method specified in options%lls_solver
 !  Input:
 !    A         - LHS matrix of the least squares problem 
-!    b         - The RHS, overwritten with x on output 
+!    b         - The RHS, overwritten with result x on output
 !    n         - Number of columns in A
 !    m         - Number of rows in A
 !    inform    - NLLS_inform structure
-!    options   - NLLS_options structure
 !    w         - workspace structure
+!    options   - NLLS_options structure
 !    pd        - logical, true if A is known to be positive definite
-!  Output:
-!    A_out     - output copy of the original A matrix
-!    x         - solution vector 
-!    inform    - NLLS_inform structure
-!    work      - updated workspace structure
 !  -----------------------------------------------------------------
     implicit none
+    real(wp), intent(inout), contiguous :: A(:,:), b(:)
     integer, intent(in) :: n, m
-    real(wp), intent(in) :: A(n,m)
-    real(wp), intent(in) :: b(m)
-    real(wp), intent(out) :: A_out(n,m)
-    real(wp), intent(out) :: x(n)
     type(NLLS_inform), intent(inout) :: inform
-    type(NLLS_options), Intent(In) :: options 
     type(solve_LLS_work), intent(inout) :: w
-    logical, intent(in) :: pd
-
-    real(wp) :: b_out(m)
-
-    A_out = A
-    b_out = b
-
-    call solve_LLS_nocopy(A_out, b_out, n, m, inform, w, options, pd)
-    if (inform%status == 0) then
-      x(1:n) = b_out(1:n)
-    end if
-
-  end subroutine solve_LLS
-
-  subroutine solve_LLS_nocopy(A, b, n, m, inform, w, options, pd)
-!  linear solver core which overwrites A and b. 
-    implicit none
-    integer, intent(in) :: n, m
-    real(wp), dimension(m,n), intent(inout) :: A
-    real(wp), dimension(m), intent(inout) :: b
-    type(NLLS_inform), intent(inout) :: inform
     type(NLLS_options), intent(in) :: options 
-    type(solve_LLS_work), intent(inout) :: w
     logical, intent(in) :: pd
 
     select case (options%lls_solver) 
@@ -92,13 +61,12 @@ contains
     end select
 
 100 continue
-  end subroutine solve_LLS_nocopy
+  end subroutine solve_LLS
 
   subroutine solve_gels(A,b,n,m,inform,w,options)
 !   Wrapper around LAPACK's ?gels
    implicit none 
-   REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
-   REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
+   real(wp), intent(inout), contiguous :: A(:,:), b(:)
    INTEGER, INTENT(IN) :: n, m
    type(NLLS_inform), INTENT(INOUT) :: inform
    type(NLLS_options), Intent(In) :: options 
@@ -129,8 +97,7 @@ contains
   subroutine solve_gesv(A,b,n,inform)
 !   Wrapper around LAPACK's ?gesv
     implicit none
-    REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
-    REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
+    real(wp), intent(inout), contiguous :: A(:,:), b(:)
     INTEGER, INTENT(IN) :: n
     type(NLLS_inform), INTENT(INOUT) :: inform
 
@@ -148,8 +115,8 @@ contains
   subroutine solve_posv(A,b,n,inform)
 !   Wrapper around LAPACK's ?posv for positive definite systems
     implicit none
-    REAL(wp), DIMENSION(:,:), INTENT(INOUT) :: A
-    REAL(wp), DIMENSION(:), INTENT(INOUT) :: b
+    REAL(wp), DIMENSION(:,:), INTENT(INOUT), contiguous :: A
+    REAL(wp), DIMENSION(:), INTENT(INOUT), contiguous :: b
     INTEGER, INTENT(IN) :: n
     type(NLLS_inform), INTENT(INOUT) :: inform
 

--- a/libRALFit/src/ral_nlls_linear.F90
+++ b/libRALFit/src/ral_nlls_linear.F90
@@ -1,0 +1,135 @@
+! ral_nlls_linear :: linear solvers for internal use in RALFit
+
+#include "preprocessor.FPP"
+
+module MODULE_PREC(ral_nlls_linear)
+  use MODULE_PREC(ral_nlls_workspaces), only: wp, solve_LLS_work, NLLS_inform, &
+                                              NLLS_options, NLLS_ERROR_WORKSPACE_ERROR, &
+                                              NLLS_ERROR_FROM_EXTERNAL
+  implicit none
+
+  private
+  public :: solve_LLS, solve_LLS_nocopy
+
+contains
+  subroutine solve_LLS(A,b,A_out,x,n,m,inform,w,options,pd)
+!  -----------------------------------------------------------------
+!  solve_LLS, a subroutine to solve a linear least squares problem
+!  -----------------------------------------------------------------
+!  Solves the linear least squares problem Ax = b
+!  using the method specified in options%lls_solver
+!  Input:
+!    A         - LHS matrix of the least squares problem (m x n)
+!    b         - The RHS, overwritten with x on output (m x 1)
+!    n         - Number of columns in A
+!    m         - Number of rows in A
+!    inform    - NLLS_inform structure
+!    options   - NLLS_options structure
+!    w         - workspace structure
+!    pd        - logical, true if A is known to be positive definite
+!  Output:
+!    A_out     - output copy of the original A matrix (m x n)
+!    x         - solution vector (n x 1)
+!    inform    - NLLS_inform structure
+!    work      - updated workspace structure
+!  -----------------------------------------------------------------
+    implicit none
+    real(wp), dimension(:), intent(in) :: A
+    real(wp), dimension(:), intent(in) :: b
+    real(wp), dimension(:), intent(out) :: A_out
+    real(wp), dimension(:), intent(out) :: x
+    integer, intent(in) :: n, m
+    type(NLLS_inform), intent(inout) :: inform
+    type(NLLS_options), Intent(In) :: options 
+    type(solve_LLS_work), intent(inout) :: w
+    logical, intent(in) :: pd
+
+    A_out = A
+    x = b
+
+    call solve_LLS_nocopy(A_out, x, n, m, inform, w, options, pd)
+
+  end subroutine solve_LLS
+
+  subroutine solve_LLS_nocopy(A, b, n, m, inform, w, options, pd)
+!  linear solver core which overwrites A and b. 
+    implicit none
+    real(wp), dimension(:), intent(inout) :: A
+    real(wp), dimension(:), intent(inout) :: b
+    integer, intent(in) :: n, m
+    type(NLLS_inform), intent(inout) :: inform
+    type(NLLS_options), intent(in) :: options 
+    type(solve_LLS_work), intent(inout) :: w
+    logical, intent(in) :: pd
+
+    select case (options%lls_solver) 
+      case (1)  ! LAPACK
+        if (pd) then
+          call solve_posv(A,b,n,inform,options)
+        else
+          if (.not. w%allocated) then
+            inform%status = NLLS_ERROR_WORKSPACE_ERROR
+            goto 100
+          end if
+          call solve_gels(A,b,n,m,inform,w,options)
+        end if
+    end select
+
+    if (inform%external_return /= 0 ) then
+      inform%status = NLLS_ERROR_FROM_EXTERNAL
+    end if 
+
+100   continue
+  end subroutine solve_LLS_nocopy
+
+  subroutine solve_gels(A,b,n,m,inform,w,options)
+!   Wrapper around LAPACK's ?gels
+   implicit none 
+   REAL(wp), DIMENSION(:), INTENT(IN) :: A
+   REAL(wp), DIMENSION(:), INTENT(IN) :: b
+   INTEGER, INTENT(IN) :: n, m
+   type(NLLS_inform), INTENT(INOUT) :: inform
+   type(NLLS_options), Intent(In) :: options 
+
+   integer, Parameter :: nrhs = 1
+   integer :: lwork, lda, ldb
+   type( solve_LLS_work ), Intent(inout) :: w
+
+   lwork = size(w%work)
+
+   if (options%Fortran_Jacobian) then
+      lda = m
+      ldb = max(m,n)
+      call PREC(gels)('N', m, n, nrhs, A, lda, w%temp, ldb, w%work, lwork, &
+           inform%external_return)
+   else
+      lda = n
+      ldb = max(m,n)
+      call PREC(gels)('T', n, m, nrhs, A, lda, w%temp, ldb, w%work, lwork, &
+           inform%external_return)
+   end if
+   if (inform%external_return /= 0 ) then
+      inform%status = NLLS_ERROR_FROM_EXTERNAL
+      inform%external_name = 'lapack_?gels'
+   end if
+
+  end subroutine solve_gels
+
+  subroutine solve_posv(A,b,n,inform,options)
+!   Wrapper around LAPACK's ?posv for positive definite systems
+    implicit none
+    REAL(wp), DIMENSION(:), INTENT(IN) :: A
+    REAL(wp), DIMENSION(:), INTENT(IN) :: b
+    INTEGER, INTENT(IN) :: n
+    type(NLLS_inform), INTENT(INOUT) :: inform
+    type(NLLS_options), Intent(In) :: options
+
+    call PREC(posv)('N', n, 1, A, n, b, n, inform%external_return)
+    if (inform%external_return /= 0 ) then
+       inform%status = NLLS_ERROR_FROM_EXTERNAL
+       inform%external_name = 'lapack_?posv'
+    end if
+
+  end subroutine solve_posv
+
+end module MODULE_PREC(ral_nlls_linear)

--- a/libRALFit/src/ral_nlls_linear.F90
+++ b/libRALFit/src/ral_nlls_linear.F90
@@ -47,7 +47,7 @@ contains
           call solve_posv(A,b,n,inform)
         else
           if (n == m) then
-            call solve_gesv(A,b,n,inform)
+            call solve_gesv(A,b,n,inform,w)
           else
             if (.not. w%allocated) then
               inform%status = NLLS_ERROR_WORKSPACE_ERROR
@@ -94,17 +94,15 @@ contains
 
   end subroutine solve_gels
 
-  subroutine solve_gesv(A,b,n,inform)
+  subroutine solve_gesv(A,b,n,inform,w)
 !   Wrapper around LAPACK's ?gesv
     implicit none
     real(wp), intent(inout), contiguous :: A(:,:), b(:)
     INTEGER, INTENT(IN) :: n
     type(NLLS_inform), INTENT(INOUT) :: inform
+    type(solve_LLS_work), intent(inout) :: w
 
-    ! NB: we never actually use ipiv in the library
-    integer, dimension(n) :: ipiv
-
-    call PREC(gesv)(n, 1, A, n, ipiv, b, n, inform%external_return)
+    call PREC(gesv)(n, 1, A, n, w%ipiv, b, n, inform%external_return)
     if (inform%external_return /= 0 ) then
        inform%status = NLLS_ERROR_FROM_EXTERNAL
        inform%external_name = 'lapack_?gesv'

--- a/libRALFit/src/ral_nlls_workspaces.F90
+++ b/libRALFit/src/ral_nlls_workspaces.F90
@@ -1254,7 +1254,7 @@ contains
 
     inform%status = 0
     lwork = max(1, min(m,n) + max(min(m,n), 1)*4)
-    allocate( w%temp(max(m,n)),w%work(lwork),w%Jlls(n,m), stat = inform%alloc_status)
+    allocate( w%temp(max(m,n)),w%work(lwork),w%Jlls(m,n), stat = inform%alloc_status)
     If (inform%alloc_status /= 0) Then
       Call remove_workspace_solve_LLS(w,options)
       inform%status = NLLS_ERROR_ALLOCATION

--- a/libRALFit/src/ral_nlls_workspaces.F90
+++ b/libRALFit/src/ral_nlls_workspaces.F90
@@ -602,6 +602,7 @@ module MODULE_PREC(ral_nlls_workspaces)
   type, public :: solve_LLS_work ! workspace for subroutine solve_LLS
      logical :: allocated = .false.
      real(wp), allocatable :: temp(:), work(:), Jlls(:,:)
+     integer, allocatable :: ipiv(:)
   end type solve_LLS_work
 
   type, public :: min_eig_symm_work ! workspace for subroutine min_eig_work
@@ -1254,7 +1255,7 @@ contains
 
     inform%status = 0
     lwork = max(1, min(m,n) + max(min(m,n), 1)*4)
-    allocate( w%temp(max(m,n)),w%work(lwork),w%Jlls(m,n), stat = inform%alloc_status)
+    allocate( w%temp(max(m,n)),w%work(lwork),w%Jlls(m,n), w%ipiv(n), stat = inform%alloc_status)
     If (inform%alloc_status /= 0) Then
       Call remove_workspace_solve_LLS(w,options)
       inform%status = NLLS_ERROR_ALLOCATION
@@ -1273,6 +1274,7 @@ contains
     if(allocated( w%temp )) deallocate( w%temp, stat=ierr_dummy )
     if(allocated( w%work )) deallocate( w%work, stat=ierr_dummy )
     if(allocated( w%Jlls )) deallocate( w%Jlls, stat=ierr_dummy )
+    if(allocated( w%ipiv )) deallocate( w%ipiv, stat=ierr_dummy )
 
     w%allocated = .false.
   end subroutine remove_workspace_solve_LLS

--- a/libRALFit/test/nlls_test.F90
+++ b/libRALFit/test/nlls_test.F90
@@ -1424,7 +1424,13 @@ program nlls_test
      call all_eig_symm_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
-     call solve_LLS_tests(options,fails)
+     call solve_LLS_dgels_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
+
+     call solve_LLS_dposv_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
+
+     call solve_LLS_dgesv_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
      call findbeta_tests(options,fails)
@@ -1446,12 +1452,6 @@ program nlls_test
      no_errors_helpers = no_errors_helpers + fails
 
      call switch_to_quasi_newton_tests(options,fails)
-     no_errors_helpers = no_errors_helpers + fails
-
-     call minus_solve_spd_tests(options,fails)
-     no_errors_helpers = no_errors_helpers + fails
-
-     call minus_solve_general_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
      call matmult_inner_tests(options,fails)

--- a/libRALFit/test/nlls_test.F90
+++ b/libRALFit/test/nlls_test.F90
@@ -1424,6 +1424,9 @@ program nlls_test
      call all_eig_symm_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 
+     call solve_LLS_general_tests(options,fails)
+     no_errors_helpers = no_errors_helpers + fails
+
      call solve_LLS_dgels_tests(options,fails)
      no_errors_helpers = no_errors_helpers + fails
 

--- a/libRALFit/test/unit_test_mod.F90
+++ b/libRALFit/test/unit_test_mod.F90
@@ -2174,10 +2174,22 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      call setup_workspaces(work,n,m,options,status)
 
-     allocate(J(m,n), JT(m,n), f(m), d(n), Jd(m))
-     J = reshape([ 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
-           6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp ], [m, n])
-     f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
+     allocate(J(m,n), JT(n,m), f(m), d(n), Jd(m))
+     J(1, 1) = 1.0_wp
+     J(2, 1) = 2.0_wp
+     J(3, 1) = 3.0_wp
+     J(4, 1) = 4.0_wp
+     J(5, 1) = 5.0_wp
+     J(1, 2) = 6.0_wp
+     J(2, 2) = 7.0_wp
+     J(3, 2) = 8.0_wp
+     J(4, 2) = 9.0_wp
+     J(5, 2) = 10.0_wp
+     f(1) = 7.0_wp
+     f(2) = 9.0_wp
+     f(3) = 11.0_wp
+     f(4) = 13.0_wp
+     f(5) = 15.0_wp
 
      call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
                     d,n,m,status, &
@@ -2204,9 +2216,21 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 !          4.0_wp,  9.0_wp,
 !          5.0_wp, 10.0_wp ]
 !    Jacobian Transpose:
-     JT = reshape([ 1.0_wp, 6.0_wp, 2.0_wp, 7.0_wp, 3.0_wp, &
-           8.0_wp, 4.0_wp, 9.0_wp, 5.0_wp, 10.0_wp ], [n,m])
-     f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
+     JT(1, 1) = 1.0_wp
+     JT(2, 1) = 6.0_wp
+     JT(1, 2) = 2.0_wp
+     JT(2, 2) = 7.0_wp
+     JT(1, 3) = 3.0_wp
+     JT(2, 3) = 8.0_wp
+     JT(1, 4) = 4.0_wp
+     JT(2, 4) = 9.0_wp
+     JT(1, 5) = 5.0_wp
+     JT(2, 5) = 10.0_wp
+     f(1) = 7.0_wp
+     f(2) = 9.0_wp
+     f(3) = 11.0_wp
+     f(4) = 13.0_wp
+     f(5) = 15.0_wp
 
      options%fortran_jacobian = .false.
      call solve_LLS(jt,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &

--- a/libRALFit/test/unit_test_mod.F90
+++ b/libRALFit/test/unit_test_mod.F90
@@ -1768,7 +1768,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      call more_sorensen(A,g,n,m,Delta,d,normd,options,status,&
           work%calculate_step_ws%more_sorensen_ws)
      if (status%status .ne. 0) then
-        write(*,*) 'Error: unexpected error in more-sorensen test with non-zero shift'
+        write(*,*) 'Error: unexpected error in more-sorensen test with non-zero shift and nd /= Delta'
         write(*,*) 'status = ', status%status, ' returned'
         fails = fails + 1
         status%status = 0
@@ -1782,7 +1782,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      call more_sorensen(A,g,n,m,Delta,d,normd,options,status,&
           work%calculate_step_ws%more_sorensen_ws)
      if (status%status .ne. 0) then
-        write(*,*) 'Error: unexpected error in more-sorensen test with non-zero shift'
+        write(*,*) 'Error: unexpected error in more-sorensen test with non-zero shift and nd = Delta'
         write(*,*) 'status = ', status%status, ' returned'
         fails = fails + 1
         status%status = 0
@@ -1814,6 +1814,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
           work%calculate_step_ws%more_sorensen_ws)
      if (status%status .ne. NLLS_ERROR_MS_MAXITS) then
         write(*,*) 'Error: Expected maximum iterations error in more_sorensen'
+        write(*,*) 'status = ', status%status, ' returned'
         fails = fails + 1
      end if
      status%status = 0
@@ -1935,6 +1936,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
            if ( (status%status .ne. 0)) then
               write(*,*) 'Error: unexpected error in ', method_name
               write(*,*) '(status = ',status%status,')'
+              write(*,*) '(external return = ',status%external_return,')'
               write(*,*) 'TR Book Example ',problem_name
               fails = fails + 1
               status%status = 0
@@ -2150,12 +2152,12 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
    end subroutine all_eig_symm_tests
 
-   subroutine solve_LLS_tests(options,fails)
+   subroutine solve_LLS_dgels_tests(options,fails)
 
      type( nlls_options ), intent(inout) :: options
      integer, intent(out) :: fails
 
-     real(wp), allocatable :: J(:), f(:), d(:), Jd(:)
+     real(wp), allocatable :: J(:,:), f(:), d(:), Jd(:), JT(:,:)
      real(wp) :: normerror
      integer :: n,m
      type( nlls_workspace ) :: work
@@ -2167,21 +2169,19 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      iw%iw_ptr => iw
 
      options%nlls_method = 1 ! dogleg
-
      n = 2
      m = 5
 
      call setup_workspaces(work,n,m,options,status)
 
-     allocate(J(n*m), f(m), d(n), Jd(m))
-     J = [ 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
-           6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp ]
+     allocate(J(m,n), JT(m,n), f(m), d(n), Jd(m))
+     J = reshape([ 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
+           6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp ], [m, n])
      f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
 
      call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
                     d,n,m,status, &
                     work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
-     d(:) = -d(:)
      if ( status%status .ne. 0 ) then
          write (*, *) '[id:1] solve_LLS test failed: wrong error message returned'
         write(*,*) 'status = ', status%status, " (expected ",NLLS_ERROR_FROM_EXTERNAL,")"
@@ -2189,13 +2189,14 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      end if
      ! check answer
      call mult_J(J,n,m,d,Jd,.True.)
-     normerror = norm2(Jd + f)
+     normerror = norm2(Jd - f)
      if ( normerror > 1.0e-12_wp ) then
         ! wrong answer, as data chosen to fit
         write(*,*) 'solve_LLS test failed: wrong solution returned'
         write(*,*) '||Jd - f|| = ', normerror
         fails = fails + 1
      end if
+     status%status = 0
 
 !    J = [ 1.0_wp,  6.0_wp,
 !          2.0_wp,  7.0_wp,
@@ -2203,42 +2204,41 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 !          4.0_wp,  9.0_wp,
 !          5.0_wp, 10.0_wp ]
 !    Jacobian Transpose:
-     J = [ 1.0_wp, 6.0_wp, 2.0_wp, 7.0_wp, 3.0_wp, &
-           8.0_wp, 4.0_wp, 9.0_wp, 5.0_wp, 10.0_wp ]
+     JT = reshape([ 1.0_wp, 6.0_wp, 2.0_wp, 7.0_wp, 3.0_wp, &
+           8.0_wp, 4.0_wp, 9.0_wp, 5.0_wp, 10.0_wp ], [n,m])
      f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
 
-
-     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+     options%fortran_jacobian = .false.
+     call solve_LLS(jt,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
                     d,n,m,status, &
                     work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
-     d(:) = -d(:)
 
      if ( status%status .ne. 0 ) then
-         write (*, *) '[id:2] solve_LLS test failed: wrong error message returned'
+        write (*, *) '[id:2] solve_LLS test failed: wrong error message returned'
         write(*,*) 'status = ', status%status, " (expected ",NLLS_ERROR_FROM_EXTERNAL,")"
         fails = fails + 1
-     end if
+     else
      ! check answer using J and not JT!!!
-     J = [ 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp, 5.0_wp, &
-           6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp ]
      call mult_J(J,n,m,d,Jd,.True.)
-     normerror = norm2(Jd + f)
+     normerror = norm2(Jd - f)
      if ( normerror > 1.0e-12_wp ) then
         ! wrong answer, as data chosen to fit
         write(*,*) 'solve_LLS transpose test failed: wrong solution returned'
         write(*,*) '||J^Td - f|| = ', normerror
         fails = fails + 1
      end if
+     end if
+     options%fortran_jacobian = .true.
 
-      n = 65
-      m = 60
-     deallocate(J,f,Jd,d)
-     allocate(J(n*m), f(m), d(n))
+     n = 65
+     m = 60
+     deallocate(J,JT,f,Jd,d)
+     allocate(J(m,n), f(m), d(n))
 
      call setup_workspaces(work,n,m,options,status)
 
-     J = 1.0_wp
-     J(1:m) = 0.0_wp
+     J(:,:) = 1.0_wp
+     J(:,1) = 0.0_wp
      f = 1.0_wp
      call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
                     d,n,m,status, &
@@ -2251,21 +2251,136 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      end if
      status%status = 0
 
-     call nlls_finalize(work, options, status)
+     call remove_workspaces(work, options)
 
-     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+     call solve_LLS(j,f,j, &
                     d,n,m,status, &
                     work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
      if (status%status .ne. NLLS_ERROR_WORKSPACE_ERROR) then
         write(*,*) 'Error: workspace error not flagged when workspaces not setup'
         fails = fails + 1
      end if
+     deallocate(J,f,d)
 
 
      call reset_default_options(options)
 
-   end subroutine solve_LLS_tests
+   end subroutine solve_LLS_dgels_tests
 
+   subroutine solve_LLS_dposv_tests(options,fails)
+
+     type( nlls_options ), intent(inout) :: options
+     integer, intent(out) :: fails
+
+     real(wp), allocatable :: A(:,:), b(:), LtL(:,:), x_calc(:), x_true(:), tol
+     integer :: n
+     type( nlls_inform ) :: status
+     type(solve_LLS_work) :: w
+
+     continue
+     if (wp == np) then
+        tol = 1.0e-12_wp
+     else
+        tol = 5.0e-7_wp
+     end if
+
+     fails = 0
+
+     n = 2
+     allocate(A(n,n), b(n), LtL(n,n), x_calc(n), x_true(n))
+     A = 0.0_wp
+     A(1,1) = 4.0_wp
+     A(2,1) = 1.0_wp
+     A(1,2) = 1.0_wp
+     A(2,2) = 2.0_wp
+     x_true(1) = 1.0_wp
+     x_true(2) = 1.0_wp
+     b(1) = 5.0_wp
+     b(2) = 3.0_wp
+     call solve_LLS(A, b, LtL, x_calc, n, n, status, w, options, .true.)
+     if (status%status .ne. 0) then
+        write(*,*) 'Error: solve_LLS info = ', status%status, ' returned from solve_LLS'
+        fails = fails + 1
+     else if (norm2(x_calc-x_true) > tol) then
+       write(*,*) 'Error: incorrect value returned from solve_LLS for `dposv` case'
+        write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', tol
+        fails = fails + 1
+     end if
+
+     ! test also _nocopy variant !
+     call solve_LLS_nocopy(A, b, n, n, status, w, options, .true.)
+     if (status%status .ne. 0) then
+        write(*,*) 'Error: solve_LLS info = ', status%status, ' returned from solve_LLS'
+        fails = fails + 1
+     else if (norm2(x_calc-x_true) > tol) then
+       write(*,*) 'Error: incorrect value returned from solve_LLS for `dposv` case (nocopy)'
+        write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', tol
+        fails = fails + 1
+     end if
+
+     call reset_default_options(options)
+
+   end subroutine solve_LLS_dposv_tests
+
+   subroutine solve_LLS_dgesv_tests(options,fails)
+
+     type( nlls_options ), intent(inout) :: options
+     integer, intent(out) :: fails
+
+     real(wp), allocatable :: A(:,:), b(:), x_calc(:), x_true(:)
+     integer :: n,m
+     type( nlls_inform ) :: status
+     type( nlls_workspace ) :: work
+     type( nlls_workspace ), Target :: iw
+
+     fails = 0
+     work%iw_ptr => iw
+     iw%iw_ptr => iw
+
+     n = 2
+     m = 3
+
+     allocate(A(n,n), b(n), x_calc(n), x_true(n))
+
+     options%nlls_method = 2
+     options%model = 2
+     call setup_workspaces(work,n,m,options,status)
+
+     A = 0.0_wp
+     A(1,1) = 4.0_wp
+     A(2,1) = 1.0_wp
+     A(1,2) = 2.0_wp
+     A(2,2) = 2.0_wp
+     x_true(1) = 1.0_wp
+     x_true(2) = 1.0_wp
+     x_calc(1) = 6.0_wp
+     x_calc(2) = 3.0_wp
+     call solve_LLS_nocopy(A, x_calc, n, n, status, &
+          work%calculate_step_ws%AINT_tr_ws%solve_LLS_ws, options, .false.)
+     if (status%status .ne. 0) then
+        write(*,*) 'Error: info = ', status%status, ' returned from solve_LLS'
+        fails = fails + 1
+        status%status = 0
+     else if (norm2(x_true-x_calc) > 1e-12) then
+       write(*,*) 'Error: incorrect value returned from solve_LLS for `dgesv` case'
+       write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', 1e-12 
+       fails = fails + 1
+     end if
+
+     A = 0.0_wp
+     b(1) = 6.0_wp
+     b(2) = 3.0_wp
+     call solve_LLS_nocopy(A, b, n, n, status, &
+          work%calculate_step_ws%AINT_tr_ws%solve_LLS_ws, options, .false.)
+     if (status%status .ne. NLLS_ERROR_FROM_EXTERNAL) then
+        write(*,*) 'Error: expected error return from solve_LLS, got info = ', status%status
+        fails = fails + 1
+     end if
+
+     call nlls_finalize(work,options,status)
+     call reset_default_options(options)
+
+   end subroutine solve_LLS_dgesv_tests
 
    subroutine findbeta_tests(options,fails)
 
@@ -2607,126 +2722,6 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      call reset_default_options(options)
 
    end subroutine switch_to_quasi_newton_tests
-
-
-   subroutine minus_solve_spd_tests(options,fails)
-
-     type( nlls_options ), intent(inout) :: options
-     integer, intent(out) :: fails
-
-     real(wp), allocatable :: A(:,:), b(:), LtL(:,:), x_calc(:), x_true(:), tol
-     integer :: n
-     type( nlls_inform ) :: status
-
-     continue
-     if (wp == np) then
-        tol = 1.0e-12_wp
-     else
-        tol = 5.0e-7_wp
-     end if
-
-     fails = 0
-
-     n = 2
-     allocate(A(n,n), b(n), LtL(n,n), x_calc(n), x_true(n))
-     A = 0.0_wp
-     A(1,1) = 4.0_wp
-     A(2,1) = 1.0_wp
-     A(1,2) = 1.0_wp
-     A(2,2) = 2.0_wp
-     x_true(1) = 1.0_wp
-     x_true(2) = 1.0_wp
-     b(1) = 5.0_wp
-     b(2) = 3.0_wp
-     ! note: b is inverted in minus_solve_spd, so we need to invert it (previously)
-     b(:) = -b(:)
-     call minus_solve_spd(A,b,LtL,x_calc,n,status)
-     if (status%status .ne. 0) then
-        write(*,*) 'Error: minus_solve_spd info = ', status%status, ' returned from minus_solve_spd'
-        fails = fails + 1
-     else if (norm2(x_calc-x_true) > tol) then
-        write(*,*) 'Error: incorrect value returned from minus_solve_spd'
-        write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', tol
-        fails = fails + 1
-     end if
-
-     ! test also _nocopy variant !
-     call minus_solve_spd_nocopy(A,b,x_calc,n,status)
-     if (status%status .ne. 0) then
-        write(*,*) 'Error: minus_solve_spd_nocopy info = ', status%status, ' returned from minus_solve_spd'
-        fails = fails + 1
-     else if (norm2(x_calc-x_true) > tol) then
-        write(*,*) 'Error: incorrect value returned from minus_solve_spd_nocopy'
-        write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', tol
-        fails = fails + 1
-     end if
-
-     call reset_default_options(options)
-
-   end subroutine minus_solve_spd_tests
-
-   subroutine minus_solve_general_tests(options,fails)
-
-     type( nlls_options ), intent(inout) :: options
-     integer, intent(out) :: fails
-
-     real(wp), allocatable :: A(:,:), b(:), x_calc(:), x_true(:)
-     integer :: n,m
-     type( nlls_inform ) :: status
-     type( nlls_workspace ) :: work
-     type( nlls_workspace ), Target :: iw
-
-     fails = 0
-     work%iw_ptr => iw
-     iw%iw_ptr => iw
-
-     n = 2
-     m = 3
-
-     allocate(A(n,n), b(n), x_calc(n), x_true(n))
-
-     options%nlls_method = 2
-     options%model = 2
-     call setup_workspaces(work,n,m,options,status)
-
-     A = 0.0_wp
-     A(1,1) = 4.0_wp
-     A(2,1) = 1.0_wp
-     A(1,2) = 2.0_wp
-     A(2,2) = 2.0_wp
-     x_true(1) = 1.0_wp
-     x_true(2) = 1.0_wp
-     b(1) = 6.0_wp
-     b(2) = 3.0_wp
-     ! note: b is inverted in minus_solve_general, so we need to invert it (previously)
-     b(:) = -b(:)
-     call minus_solve_general(A,b,x_calc,n,status,&
-          work%calculate_step_ws%AINT_tr_ws%minus_solve_general_ws)
-     if (status%status .ne. 0) then
-        write(*,*) 'Error: info = ', status%status, ' returned from minus_solve_general'
-        fails = fails + 1
-        status%status = 0
-     else if (norm2(x_true-x_calc) > 1e-12) then
-        write(*,*) 'Error: incorrect value returned from minus_solve_general'
-        fails = fails + 1
-     end if
-
-     A = 0.0_wp
-     b(1) = 6.0_wp
-     b(2) = 3.0_wp
-     ! note: b is inverted in minus_solve_general, so we need to invert it (previously)
-     b(:) = -b(:)
-     call minus_solve_general(A,b,x_calc,n,status,&
-          work%calculate_step_ws%AINT_tr_ws%minus_solve_general_ws)
-     if (status%status .ne. NLLS_ERROR_FROM_EXTERNAL) then
-        write(*,*) 'Error: expected error return from minus_solve_general, got info = ', status%status
-        fails = fails + 1
-     end if
-
-     call nlls_finalize(work,options,status)
-     call reset_default_options(options)
-
-   end subroutine minus_solve_general_tests
 
    subroutine matmult_inner_tests(options,fails)
 

--- a/libRALFit/test/unit_test_mod.F90
+++ b/libRALFit/test/unit_test_mod.F90
@@ -10,6 +10,7 @@ module MODULE_PREC(unit_test_mod)
 
   use MODULE_PREC(ral_nlls)
   use MODULE_PREC(ral_nlls_internal)
+  use MODULE_PREC(ral_nlls_linear)
   use MODULE_PREC(ral_nlls_workspaces)
   implicit none
 
@@ -2177,8 +2178,10 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
            6.0_wp, 7.0_wp, 8.0_wp, 9.0_wp, 10.0_wp ]
      f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
 
-     call solve_LLS(J,f,n,m,d,status, &
-          work%calculate_step_ws%dogleg_ws%solve_LLS_ws,.True.)
+     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+                    d,n,m,status, &
+                    work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
+     d(:) = -d(:)
      if ( status%status .ne. 0 ) then
          write (*, *) '[id:1] solve_LLS test failed: wrong error message returned'
         write(*,*) 'status = ', status%status, " (expected ",NLLS_ERROR_FROM_EXTERNAL,")"
@@ -2204,8 +2207,12 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
            8.0_wp, 4.0_wp, 9.0_wp, 5.0_wp, 10.0_wp ]
      f = [ 7.0_wp, 9.0_wp, 11.0_wp, 13.0_wp, 15.0_wp ]
 
-     call solve_LLS(J,f,n,m,d,status, &
-          work%calculate_step_ws%dogleg_ws%solve_LLS_ws,.False.)
+
+     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+                    d,n,m,status, &
+                    work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
+     d(:) = -d(:)
+
      if ( status%status .ne. 0 ) then
          write (*, *) '[id:2] solve_LLS test failed: wrong error message returned'
         write(*,*) 'status = ', status%status, " (expected ",NLLS_ERROR_FROM_EXTERNAL,")"
@@ -2233,8 +2240,10 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      J = 1.0_wp
      J(1:m) = 0.0_wp
      f = 1.0_wp
-     call solve_LLS(J,f,n,m,d,status, &
-          work%calculate_step_ws%dogleg_ws%solve_LLS_ws,.True.)
+     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+                    d,n,m,status, &
+                    work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
+
      if ( status%status .ne. NLLS_ERROR_FROM_EXTERNAL ) then
          write (*, *) '[id:3] solve_LLS test failed: wrong error message returned'
         write(*,*) 'status = ', status%status, " (expected ",NLLS_ERROR_FROM_EXTERNAL,")"
@@ -2244,8 +2253,9 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      call nlls_finalize(work, options, status)
 
-     call solve_LLS(J,f,n,m,d,status, &
-          work%calculate_step_ws%dogleg_ws%solve_LLS_ws,.True.)
+     call solve_LLS(j,f,work%calculate_step_ws%dogleg_ws%solve_lls_ws%jlls, &
+                    d,n,m,status, &
+                    work%calculate_step_ws%dogleg_ws%solve_lls_ws,options,.false.)
      if (status%status .ne. NLLS_ERROR_WORKSPACE_ERROR) then
         write(*,*) 'Error: workspace error not flagged when workspaces not setup'
         fails = fails + 1

--- a/libRALFit/test/unit_test_mod.F90
+++ b/libRALFit/test/unit_test_mod.F90
@@ -2152,6 +2152,31 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
    end subroutine all_eig_symm_tests
 
+   subroutine solve_LLS_general_tests(options,fails)
+     ! Tests for solve_LLS that do not depend on any actual solvers, just the logic of the routine itself
+     type( nlls_options ), intent(inout) :: options
+     integer, intent(out) :: fails
+
+     ! test that a BAD_LLS_SOLVER error is returned if an invalid solver is passed in
+     real(wp), allocatable :: J(:,:), d(:)
+     integer :: n,m
+     type( solve_LLS_work ) :: work
+     type( nlls_inform ) :: inform
+
+     fails = 0
+     options%lls_solver = -1 ! invalid solver
+
+     call solve_LLS(J,d,n,m,inform,work,options,.false.)
+
+      if (inform%status .ne. NLLS_ERROR_BAD_LLS_SOLVER) then
+          write(*,*) 'Error: expected BAD_LLS_SOLVER error when passing uninitialized work to solve_LLS'
+          write(*,*) 'status = ', inform%status, ' returned'
+          fails = fails + 1
+      end if 
+
+   end subroutine solve_LLS_general_tests
+
+
    subroutine solve_LLS_dgels_tests(options,fails)
 
      type( nlls_options ), intent(inout) :: options
@@ -2168,6 +2193,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      work%iw_ptr => iw
      iw%iw_ptr => iw
 
+     options%lls_solver = 1 ! LAPACK
      options%nlls_method = 1 ! dogleg
      n = 2
      m = 5
@@ -2313,6 +2339,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      end if
 
      fails = 0
+     options%lls_solver = 1 ! LAPACK
 
      n = 2
      allocate(A(n,n), b(n), LtL(n,n), x_calc(n), x_true(n))
@@ -2359,6 +2386,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      allocate(A(n,n), b(n), x_calc(n), x_true(n))
 
+     options%lls_solver = 1 ! LAPACK
      options%nlls_method = 2
      options%model = 2
      call setup_workspaces(work,n,m,options,status)

--- a/libRALFit/test/unit_test_mod.F90
+++ b/libRALFit/test/unit_test_mod.F90
@@ -1412,7 +1412,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
       if ( c_status%iter == status%iter ) then
          resvec_error = norm2(c_status%resvec(1:c_status%iter+1) - &
               status%resvec(1:status%iter+1))
-         if (resvec_error > abstol) then
+         if (.not. resvec_error < abstol) then
             write(*,*) 'Warning: fortran and c resvec differ!'
             write(*,*) 'Different resvecs in 2-norm for'
             write(*,*) 'NLLS_METHOD = ', options%nlls_method
@@ -1940,7 +1940,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
               write(*,*) 'TR Book Example ',problem_name
               fails = fails + 1
               status%status = 0
-           elseif ( normd - Delta > 1e-3 ) then
+           elseif ( .not. normd - Delta < 1e-3 ) then
               write(*,*) 'Error: answer returned outside the TR Radius'
               write(*,*) 'TR Book Example ', trim(problem_name),' using method ',method_name
               write(*,*) 'Delta = ', Delta, '||d|| = ', normd
@@ -2051,7 +2051,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
         if (i == 1) then
            ! check result lies within the trust region
-           if ( abs(dot_product(d,d) - Delta**2) > tol ) then
+           if ( .not. abs(dot_product(d,d) - Delta**2) < tol ) then
               write(*,*) testname,'failed'
               write(*,*) 'Delta = ', Delta, '||d|| = ', sqrt(dot_product(d,d))
               write(*,*) 'sq diff = ', abs(dot_product(d,d) - Delta**2), 'tol = ', tol
@@ -2232,7 +2232,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check answer
      call mult_J(J,n,m,d,Jd,.True.)
      normerror = norm2(Jd - f)
-     if ( normerror > 1.0e-12_wp ) then
+     if ( .not. normerror < 1.0e-12_wp ) then
         ! wrong answer, as data chosen to fit
         write(*,*) 'solve_LLS test failed: wrong solution returned'
         write(*,*) '||Jd - f|| = ', normerror
@@ -2277,7 +2277,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check answer using J and not JT!!!
      call mult_J(J,n,m,d,Jd,.True.)
      normerror = norm2(Jd - f)
-     if ( normerror > 1.0e-12_wp ) then
+     if ( .not. normerror < 1.0e-12_wp ) then
         ! wrong answer, as data chosen to fit
         write(*,*) 'solve_LLS transpose test failed: wrong solution returned'
         write(*,*) '||J^Td - f|| = ', normerror
@@ -2356,7 +2356,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      if (status%status .ne. 0) then
         write(*,*) 'Error: solve_LLS info = ', status%status, ' returned from solve_LLS'
         fails = fails + 1
-     else if (norm2(b-x_true) > tol) then
+     else if (.not. norm2(b-x_true) < tol) then
        write(*,*) 'Error: incorrect value returned from solve_LLS for `dposv` case'
         write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', tol
         fails = fails + 1
@@ -2406,7 +2406,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
         write(*,*) 'Error: info = ', status%status, ' returned from solve_LLS'
         fails = fails + 1
         status%status = 0
-     else if (norm2(x_true-x_calc) > 1e-12) then
+     else if (.not. norm2(x_true-x_calc) < 1e-12) then
        write(*,*) 'Error: incorrect value returned from solve_LLS for `dgesv` case'
        write(*,*) 'diff norm 2 = ', norm2(x_calc-x_true), 'tol = ', 1e-12 
        fails = fails + 1
@@ -2449,7 +2449,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      if (status%status .ne. 0) then
         write(*,*) 'error -- findbeta did not work: info /= 0'
         fails = fails + 1
-     else if ( ( norm2( a + beta * b ) - 10.0_wp ) > 1e-12 ) then
+     else if ( .not. ( norm2( a + beta * b ) - 10.0_wp ) < 1e-12 ) then
         write(*,*) 'error -- findbeta did not work'
         write(*,*) '|| x + beta y|| = ', norm2( (a + beta * b)-10.0_wp)
         fails = fails + 1
@@ -2493,7 +2493,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      normfnew = 1.0_wp
      md = 1.5_wp
      call calculate_rho(normf, normfnew, md, rho,options)
-     if ( abs(rho - 3.0_wp) > 1e-10) then
+     if ( .not. abs(rho - 3.0_wp) < 1e-10) then
         write(*,*) 'Unexpected answer from calculate_rho'
         write(*,*) 'Expected 3.0, got ', rho
         fails = fails + 1
@@ -2502,7 +2502,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! now, let's check one is returned if alpha = beta
      normfnew = 2.0_wp
      call calculate_rho(normf, normfnew, md, rho,options)
-     if (abs(rho - 1.0_wp) > 1e-10) then
+     if (.not. abs(rho - 1.0_wp) < 1e-10) then
         write(*,*) 'Unexpected answer from calculate_rho'
         write(*,*) 'Expected 1.0, got ', rho
         fails = fails + 1
@@ -2512,7 +2512,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! finally, check that 1 is returned if denominator = 0
      md = 2.0_wp
      call calculate_rho(normf, normfnew, md, rho,options)
-     if (abs(rho - 1.0_wp) > 1e-10) then
+     if (.not. abs(rho - 1.0_wp) < 1e-10) then
         write(*,*) 'Unexpected answer from calculate_rho'
         write(*,*) 'Expected 1.0, got ', rho
         fails = fails + 1
@@ -2552,7 +2552,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check if rho reduced...
      rho = options%eta_success_but_reduce - 0.5_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( work%Delta >= 100.0_wp ) then
+     if ( .not. work%Delta <= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not decrease as expected: delta = ', work%Delta
         fails = fails + 1
@@ -2562,7 +2562,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check if rho stays the same...
      rho = (options%eta_success_but_reduce + options%eta_very_successful) / 2
      call update_trust_region_radius(rho,options,status,work)
-     if ( abs(work%Delta - 100.0_wp) > 1e-12 ) then
+     if ( .not. abs(work%Delta - 100.0_wp) < 1e-12 ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not stay the same: Delta = ', work%Delta
         fails = fails + 1
@@ -2573,7 +2573,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      rho = (options%eta_very_successful + options%eta_too_successful) / 2
      work%norm_S_d = 100.0_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( work%Delta <= 100.0_wp ) then
+     if ( .not. work%Delta >= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not incease: delta = ', work%Delta
         fails = fails + 1
@@ -2584,7 +2584,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check if rho stays the same because too successful...
      rho = options%eta_too_successful + 1.0_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( abs(work%Delta - 100.0_wp) > 1e-12 ) then
+     if ( .not. abs(work%Delta - 100.0_wp) < 1e-12 ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not stay the same: delta = ', work%Delta
         fails = fails + 1
@@ -2609,7 +2609,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      ! check if rho stays the same because too successful...
      rho = options%eta_too_successful + 1.0_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( abs(work%Delta - 100.0_wp) > 1e-12 ) then
+     if ( .not. abs(work%Delta - 100.0_wp) < 1e-12 ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not stay the same: delta = ', work%Delta
         fails = fails + 1
@@ -2618,7 +2618,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      rho = options%eta_success_but_reduce - 0.5_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( work%Delta >= 100.0_wp ) then
+     if ( .not. work%Delta <= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not decrease as expected: delta = ', work%Delta
         fails = fails + 1
@@ -2627,7 +2627,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
 
      rho = options%eta_successful - 10.0_wp
      call update_trust_region_radius(rho,options,status,work)
-     if ( work%Delta >= 100.0_wp ) then
+     if ( .not. work%Delta <= 100.0_wp ) then
         write(*,*) 'Unexpected answer from update_trust_region_radius'
         write(*,*) 'Delta did not decrease as expected: delta = ', work%Delta
         fails = fails + 1
@@ -2698,7 +2698,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      x = 1.0_wp
      J = [ 1.0 , 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
      call mult_J(J,m,n,x,Jx,.True.)
-     if ( norm2( Jx - [16.0, 20.0 ] ) > 1e-12) then
+     if ( .not. norm2( Jx - [16.0, 20.0 ] ) < 1e-12) then
         write(*,*) 'error :: mult_J test failed'
         fails = fails + 1
      end if
@@ -2726,7 +2726,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      x = 1.0_wp
      J = [ 1.0 , 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 ]
      call mult_Jt(J,n,m,x,Jtx,.True.)
-     if ( norm2( Jtx - [10.0, 26.0 ] ) > 1e-12) then
+     if ( .not. norm2( Jtx - [10.0, 26.0 ] ) < 1e-12) then
         write(*,*) 'error :: mult_Jt test failed'
         fails = fails + 1
      end if
@@ -2794,7 +2794,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      do i = 1,n
         diff(i) = norm2(AtA(:,i) - AtA_expected(:,i))
      end do
-     if (norm2(diff) > 1e-10) then
+     if (.not. norm2(diff) < 1e-10) then
         write(*,*) 'error :: matmult_inner test failed'
         fails = fails + 1
      end if
@@ -2833,7 +2833,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      do i = 1,m
         diff(i) = norm2(AAt(:,i) - AAt_expected(:,i))
      end do
-     if (norm2(diff) > 1e-10) then
+     if (.not. norm2(diff) < 1e-10) then
         write(*,*) 'error :: matmult_outer test failed'
         fails = fails + 1
      end if
@@ -2871,7 +2871,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      do i = 1, n
         diff(i) = norm2(xxt(i,:) - xxt_exact(i,:))
      end do
-     if (norm2(diff) > 1e-12) then
+     if (.not. norm2(diff) < 1e-12) then
         write(*,*) 'error :: outer_product test failed'
         fails = fails +1
      end if
@@ -2943,7 +2943,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
         call min_eig_symm(A,n,ew,ev,options,status, &
              work%calculate_step_ws%more_sorensen_ws%min_eig_symm_ws)
 
-        if ( (abs( ew + 6.0_wp ) > tol ).or.(status%status .ne. 0) ) then
+        if ( .not. (abs( ew + 6.0_wp ) < tol ).or.(status%status .ne. 0) ) then
            write(*,*) 'error :: min_eig_symm test failed -- wrong eig found'
            write(*,*) 'diff = ', abs( ew + 6.0_wp ), 'tol = ', tol
            fails = fails +1
@@ -2958,7 +2958,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
               errnorm = errnorm + (avec(row) - ew * ev(row))**2
            end do
            errnorm = sqrt(errnorm)
-           if (errnorm > tol) then
+           if (.not. errnorm < tol) then
               write(*,*) 'error :: min_eig_symm test failed -- not an eigenvector'
               write(*,*) 'diff = ', errnorm, 'tol = ', tol
               fails = fails +1
@@ -3031,7 +3031,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      if ( status%status .ne. 0 ) then
         write(*,*) 'error :: max_eig test failed, status = ', status%status
         fails = fails + 1
-     elseif ( (abs( ew - 10.0_wp) > tol) ) then
+     elseif ( .not. (abs( ew - 10.0_wp) < tol) ) then
         write(*,*) 'error :: max_eig test failed, incorrect answer'
         write(*,*) 'expected 10.0, got ', ew
         fails = fails + 1
@@ -3075,7 +3075,7 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
               diff(i) = diff(i) + (tmpA(2) - ew * tmpB(2))**2
               diff(i) = sqrt(diff(i))
            end do
-           if (norm2(diff) > 1e-10) then
+           if (.not. norm2(diff) < 1e-10) then
               write(*,*) 'error :: hard case of max_eig test failed - wrong vectors returned'
               write(*,*) 'diff = ', diff
               fails = fails + 1
@@ -3149,12 +3149,12 @@ SUBROUTINE eval_F( status, n_dummy, m, X, f, params)
      AplusSigma = 0.0_wp
      sigma = 5.0_wp
      call shift_matrix(A,sigma,AplusSigma,n)
-     if ( ( (AplusSigma(1,1)-6.0_wp) > 1e-12) .or. &
-          ((AplusSigma(2,2) - 6.0_wp) > 1e-12) ) then
+     if ( .not. ( (AplusSigma(1,1)-6.0_wp) < 1e-12) .and. &
+          (.not. (AplusSigma(2,2) - 6.0_wp) < 1e-12) ) then
         write(*,*) 'Error: incorrect return from shift_matrix'
         fails = fails + 1
-     elseif ( ( (AplusSigma(1,2)-1.0_wp) > 1e-12) .or. &
-          ((AplusSigma(2,1) - 1.0_wp) > 1e-12) ) then
+     elseif ( .not. ( (AplusSigma(1,2)-1.0_wp) < 1e-12) .and. &
+          (.not.(AplusSigma(2,1) - 1.0_wp) < 1e-12) ) then
         write(*,*) 'Error: incorrect return from shift_matrix'
         fails = fails + 1
      end if


### PR DESCRIPTION
This PR changes the following:
- adds a new module, `ral_nlls_linear`, which provides an interface to linear solvers
- unifies `solve_LLS` and the three `minus_solve_*` functions to all use this interface
  - in the process, I've removed some unnecessary matrix copies made via `minus_solve_spd`
- adds additional error handling and debug information
- fixes #138 